### PR TITLE
create batch file for installation in windows

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -39,6 +39,16 @@ $ curl -sSL https://github.com/passff/passff/releases/download/1.0.0/install_hos
 This script will download the host application (a small python script) and the add-on's manifest file (a JSON config file) and put them in the right place.
 If you're concerned about executing a script that downloads files from the web, you can download the files yourself and run the script with the `--local` option instead or link the files yourself. Details below.
 
+#### Windows
+Download the `install_host_app.bat` script from [our releases page](https://github.com/passff/passff/releases) and execute it from within a shell with a correct PATH.
+*The rule of thumb is: if you can execute pass and python from your shell, then your host application will be installed correctly.*
+
+```
+> install_host_app.bat [firefox|chrome|opera|chromium|vivaldi]
+```
+
+Note: Older Windows versions might require powershell to be installed manually as the install script uses powershell internally. Windows 10 users should be fine out of the box.
+
 #### Latest from GitHub
 Clone the repository. Then, from the project's `host/` directory, execute the installation script for your desired browser (`firefox`, `chrome`, `opera`, `chromium`, or `vivaldi`).
 

--- a/src/host/install_host_app.bat
+++ b/src/host/install_host_app.bat
@@ -1,0 +1,109 @@
+@ECHO OFF
+SETLOCAL
+
+SET "APP_NAME=passff"
+SET "VERSION=1.0.0"
+SET "HOST_URL=https://github.com/passff/passff/releases/download/%VERSION%/passff.py"
+SET "MANIFEST_URL=https://github.com/passff/passff/releases/download/%VERSION%/passff.json"
+
+SET "TARGET_DIR=%APPDATA%\%APP_NAME%"
+SET "HOST_MANIFEST=%APP_NAME%.json"
+SET "HOST_SCRIPT=%APP_NAME%.py"
+SET "HOST_BATCH=%APP_NAME%.bat"
+
+SET "HOST_MANIFEST_FULL=%TARGET_DIR%\%HOST_MANIFEST%"
+SET "HOST_SCRIPT_FULL=%TARGET_DIR%\%HOST_SCRIPT%"
+SET "HOST_BATCH_FULL=%TARGET_DIR%\%HOST_BATCH%"
+
+SET "USE_LOCAL_FILES="
+SET "TARGET_REG="
+
+REM check prerequisites: is python installed & in path?
+python --version >NUL 2> NUL || (
+    ECHO "python not found in PATH. Please execute this command in a shell where python is in PATH"
+    EXIT /B
+)
+
+:loop
+IF NOT "%1"=="" (
+    IF "%1"=="--local" (
+        SET "USE_LOCAL_FILES=true"
+        SHIFT
+    ) ELSE IF "%1"=="--help" (
+        GOTO :help
+    ) ELSE IF "%1"=="firefox" (
+        SET "TARGET_REG=HKCU\SOFTWARE\Mozilla\NativeMessagingHosts\%APP_NAME%"
+        SHIFT
+    ) ELSE IF "%1"=="chrome"  (
+        SET "TARGET_REG=HKCU\Software\Google\Chrome\NativeMessagingHosts\%APP_NAME%"
+        SHIFT
+    ) ELSE IF "%1"=="chromium"  (
+        ECHO Chromium registry key location for Native Messaging Hosts is undocumented. Assuming key for Chrome. Please provide feedback if this worked: https://github.com/passff/passff/issues/202
+        SET "TARGET_REG=HKCU\Software\Google\Chrome\NativeMessagingHosts\%APP_NAME%"
+        SHIFT
+    ) ELSE IF "%1"=="opera"  (
+        ECHO Opera registry key location for Native Messaging Hosts is undocumented. Assuming key for Chrome. Please provide feedback if this worked: https://github.com/passff/passff/issues/202
+        SET "TARGET_REG=HKCU\Software\Google\Chrome\NativeMessagingHosts\%APP_NAME%"
+        SHIFT
+    ) ELSE IF "%1"=="vivaldi"  (
+        ECHO Vivaldi registry key location for Native Messaging Hosts is undocumented. Assuming key for Chrome. Please provide feedback if this worked: https://github.com/passff/passff/issues/202
+        SET "TARGET_REG=HKCU\Software\Google\Chrome\NativeMessagingHosts\%APP_NAME%"
+        SHIFT
+    ) ELSE (
+        SHIFT
+    )
+    GOTO :loop
+)
+
+IF "%TARGET_REG%"=="" (
+    GOTO :help
+)
+
+IF EXIST "%TARGET_DIR%" (
+    dir /AD "%TARGET_DIR%" > nul || (
+        ECHO "%TARGET_DIR%" is not a directory
+        EXIT /B
+    )
+) ELSE (
+    MKDIR "%TARGET_DIR%" 2> nul
+)
+
+IF "%USE_LOCAL_FILES%"=="true" (
+    IF NOT EXIST "%~dp0%HOST_MANIFEST%" (
+        ECHO local file "%~dp0%HOST_MANIFEST%" not found
+        EXIT /B
+    )
+    IF NOT EXIST "%~dp0%HOST_SCRIPT%" (
+        ECHO local file "%~dp0%HOST_SCRIPT%" not found
+        EXIT /B
+    )
+    COPY /Y "%~dp0%HOST_MANIFEST%" "%HOST_MANIFEST_FULL%"
+    COPY /Y "%~dp0%HOST_SCRIPT%" "%HOST_SCRIPT_FULL%"
+) ELSE (
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('%HOST_URL%', '%HOST_SCRIPT_FULL%')"
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('%MANIFEST_URL%', '%HOST_MANIFEST_FULL%')"
+)
+
+powershell -Command "(Get-Content '%HOST_MANIFEST_FULL%') -replace 'PLACEHOLDER', '%HOST_BATCH_FULL:\=/%' | Set-Content '%HOST_MANIFEST_FULL%'"
+
+(
+    ECHO @ECHO OFF
+    ECHO SET "PATH=%PATH%"
+    ECHO SET "GNUPGHOME=%GNUPGHOME%"
+    ECHO python "%HOST_SCRIPT_FULL%"  %%*
+)>"%HOST_BATCH_FULL%"
+
+REG ADD "%TARGET_REG%" /ve /d "%HOST_MANIFEST_FULL%" /f || (
+    ECHO Adding key to registry failed - maybe you need Administrator rights for this. Please run
+    ECHO REG ADD "%TARGET_REG%" /ve /d "%HOST_MANIFEST_FULL%" /f
+    ECHO manually in an administrative shell.
+)
+EXIT /B
+
+:help
+ECHO Usage: %0 [OPTION] [chrome^|chromium^|firefox^|opera^|vivaldi]
+ECHO
+ECHO Options:
+ECHO   --local    Install files from disk instead of downloading them
+ECHO   --help     Show this message"
+EXIT /B


### PR DESCRIPTION
See #202.

This pull request adds a windows batch file to install the Host Application with the same (but only long -- parameters) as the bash script.

Files are installed to `C:\Users\USERNAME\AppData\Roaming\passff`. Next to the passff.py and passff.json which will either be downloaded or installed from the current directory, a `passff.bat` will be created with the following contents:

```
@ECHO OFF
SET "PATH=<value of PATH at the time of installation>"
SET "GNUPGHOME=<value of GNUPGHOMEat the time of installation>"
python "C:\Users\USERNAME\AppData\Roaming\passff\passff.py"  %*
```

Setting PATH this way is a necessity for python to be found in most windows installations, and if the installer file is called from a shell that has access to the `pass` command, that is already configured correctly as well.

I added the GNUPGHOME variable to satisfy #201 at least in Windows. 

The approach of a wrapper-script that inherits variable values from time of installation might generally solve many issues with wrongly set PATH and other environment variables. 
This might be something we could consider for the linux side as well - we might even be able to remove big chunks of code from the settings & host application that way.