### PR TITLE
Fix computation of item quality

### DIFF
--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -317,13 +317,13 @@ PassFF.Pass = {
   getItemQuality: function(item, urlStr) {
     let url = new URL(urlStr);
     let hostGroupToMatch = url.host.replace(/^\.+/, '').replace(/\.+$/, '');
-    let hostGroupToMatchSplit = hostGroupToMatch.split('\.+');
+    let hostGroupToMatchSplit = hostGroupToMatch.split(/\.+/);
     let tldName = '';
     if (hostGroupToMatchSplit.length >= 2) {
       tldName = hostGroupToMatchSplit[hostGroupToMatchSplit.length - 1];
     }
     do {
-      let itemQuality = hostGroupToMatch.split('\.+').length * 100 + hostGroupToMatch.split('\.+').length;
+      let itemQuality = hostGroupToMatch.split(/\.+/).length * 100 + hostGroupToMatch.split(/\.+/).length;
       let hostToMatch = hostGroupToMatch;
       /*
        * Return if item has children since it is a directory!


### PR DESCRIPTION
The former version tried to split the target domain name using a string
`'.+'` which cannot be part of a domain name. It caused the generation
of a single group and the quality became trivial. The new version
matches domain names as intended.

The former code had a trivial result:

    >>> hello.world".split('\.+')
    Array [ "hello.world" ]

In contrast:

    >>> hello.world".split(/\.+/)
    Array [ "hello", "world" ]