### PR TITLE
Rename translation keys to be compatible with Chromium

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,288 +1,288 @@
 {
-  "passff.passphrase.title": {
+  "passff_passphrase_title": {
     "message": "Passwort-Speicher gesperrt"
   },
-  "passff.passphrase.description": {
+  "passff_passphrase_description": {
     "message": "Auf den Passwort-Speicher kann nicht zugegriffen werden.\nBitte entsperre zuerst deinen gpg-agent."
   },
-  "passff.menu.copy_password": {
+  "passff_menu_copy_password": {
     "message": "Kopiere Passwort"
   },
-  "passff.menu.copy_login": {
+  "passff_menu_copy_login": {
     "message": "Kopiere Login"
   },
-  "passff.menu.fill": {
+  "passff_menu_fill": {
     "message": "Ausfüllen"
   },
-  "passff.menu.fill_and_submit": {
+  "passff_menu_fill_and_submit": {
     "message": "Ausfüllen und absenden"
   },
-  "passff.menu.goto_fill": {
+  "passff_menu_goto_fill": {
     "message": "Ansurfen, ausfüllen"
   },
-  "passff.menu.goto_fill_and_submit": {
+  "passff_menu_goto_fill_and_submit": {
     "message": "Ansurfen, ausfüllen und absenden"
   },
-  "passff.menu.goto": {
+  "passff_menu_goto": {
     "message": "Ansurfen"
   },
-  "passff.menu.display": {
+  "passff_menu_display": {
     "message": "Anzeigen"
   },
-  "passff.display.title": {
+  "passff_display_title": {
     "message": "Login/Passwort"
   },
-  "passff.display.description": {
+  "passff_display_description": {
     "message": "Login: $LOGIN$\n Passwort: $PASSWORD$",
     "placeholders": {
         "login": { "content": "$1" },
         "password": { "content": "$2" }
     }
   },
-  "passff.toolbar.button.label": {
+  "passff_toolbar_button_label": {
     "message": "PassFF"
   },
-  "passff.toolbar.search.placeholder": {
+  "passff_toolbar_search_placeholder": {
     "message": "Suche"
   },
-  "passff.toolbar.refresh.label": {
+  "passff_toolbar_refresh_label": {
     "message": "Neu laden"
   },
-  "passff.toolbar.preferences.label": {
+  "passff_toolbar_preferences_label": {
     "message": "Optionen"
   },
-  "passff.toolbar.new_password.label": {
+  "passff_toolbar_new_password_label": {
     "message": "Neu"
   },
-  "passff.button.root.label": {
+  "passff_button_root_label": {
     "message": "Wurzel anzeigen"
   },
-  "passff.button.context.label": {
+  "passff_button_context_label": {
     "message": "Kontext anzeigen"
   },
-  "passff.prefs.tab.general": {
+  "passff_prefs_tab_general": {
     "message": "Allgemein"
   },
-  "passff.prefs.tab.autofilling": {
+  "passff_prefs_tab_autofilling": {
     "message": "autom. Ausfüllen"
   },
-  "passff.prefs.tab.fields": {
+  "passff_prefs_tab_fields": {
     "message": "Felder"
   },
-  "passff.prefs.tab.script": {
+  "passff_prefs_tab_script": {
     "message": "Pass Skript"
   },
-  "passff.prefs.tab.adding": {
+  "passff_prefs_tab_adding": {
     "message": "Passwörter hinzufügen"
   },
-  "passff.prefs.case-insensitive-search": {
+  "passff_prefs_case_insensitive_search": {
     "message": "Groß-Kleinschreibung ignorieren"
   },
-  "passff.prefs.case-insensitive-search-tooltip": {
+  "passff_prefs_case_insensitive_search_tooltip": {
     "message": "Mit dieser Einstellung wird bei der Suche nach einer zur Website passenden Datei keine Unterscheidung zwischen Groß- und Kleinschreibung gemacht"
   },
-  "passff.prefs.enter-behavior": {
+  "passff_prefs_enter_behavior": {
     "message": "Verhalten der Enter-Taste"
   },
-  "passff.prefs.enter-behavior-tooltip": {
+  "passff_prefs_enter_behavior_tooltip": {
     "message": "Diese Einstellung bestimmt das Standardverhalten, wenn bei einem markierten Eintrag die Enter-Taste gedrückt wird"
   },
-  "passff.prefs.fields_description": {
+  "passff_prefs_fields_description": {
     "message": "Felder werden genutzt, um Daten in deinem Passwort-Repository zu finden. PassFF versucht, den 'login', 'passwort' oder 'url' Wert (entsprechend der Standard-Syntax) oder einen passenden Datensatznamen in den Passwortdaten zu finden."
   },
-  "passff.prefs.password_input_names_label": {
+  "passff_prefs_password_input_names_label": {
     "message": "Namen für 'Passwort'-Eingabefelder"
   },
-  "passff.prefs.password_input_names_tooltip": {
+  "passff_prefs_password_input_names_tooltip": {
     "message": "Kommagetrennte Liste von Eingabefeld-Namen. Eingabefelder in der HTML-Seite, die einem dieser Namen entsprechen, werden mit dem Passwort gefüllt."
   },
-  "passff.prefs.login_input_names_label": {
+  "passff_prefs_login_input_names_label": {
     "message": "Namen für 'Login'-Eingabefelder"
   },
-  "passff.prefs.login_input_names_tooltip": {
+  "passff_prefs_login_input_names_tooltip": {
     "message": "Kommagetrennte Liste von Eingabefeld-Namen. Eingabefelder in der HTML-Seite, die einem dieser Namen entsprechen, werden mit dem Login gefüllt."
   },
-  "passff.prefs.login_field_names_label": {
+  "passff_prefs_login_field_names_label": {
     "message": "Login Datensatznamen"
   },
-  "passff.prefs.login_field_names_tooltip": {
+  "passff_prefs_login_field_names_tooltip": {
     "message": "Kommaseparierte Liste von Datensatznamen. Der erste übereinstimmende Wert in den Passwortdaten wird als 'login' verwendet."
   },
-  "passff.prefs.password_field_names_label": {
+  "passff_prefs_password_field_names_label": {
     "message": "Passwort Datensatznamen"
   },
-  "passff.prefs.password_field_names_tooltip": {
+  "passff_prefs_password_field_names_tooltip": {
     "message": "Kommaseparierte Liste von Datensatznamen. Der erste übereinstimmende Wert in den Passwortdaten wird als 'Passwort' verwendet"
   },
-  "passff.prefs.url_field_names_label": {
+  "passff_prefs_url_field_names_label": {
     "message": "URL  Datensatznamen"
   },
-  "passff.prefs.url_field_names_tooltip": {
+  "passff_prefs_url_field_names_tooltip": {
     "message": "Kommaseparierte Liste von Datensatznamen. Der erste übereinstimmende Wert in den Passwortdaten wird als 'URL' verwendet"
   },
-  "passff.prefs.command_label": {
+  "passff_prefs_command_label": {
     "message": "Pass Kommando"
   },
-  "passff.prefs.command_tooltip": {
+  "passff_prefs_command_tooltip": {
     "message": "Der Pfad zum 'pass' Skript"
   },
-  "passff.prefs.commandArgs_label": {
+  "passff_prefs_commandArgs_label": {
     "message": "Argumente"
   },
-  "passff.prefs.commandArgs_tooltip": {
+  "passff_prefs_commandArgs_tooltip": {
     "message": "Argumente, die dem 'pass' Skript bei der Ausführung übergeben werden."
   },
-  "passff.prefs.shell_label": {
+  "passff_prefs_shell_label": {
     "message": "Pass Shell"
   },
-  "passff.prefs.shell_tooltip": {
+  "passff_prefs_shell_tooltip": {
     "message": "Die Shell, innerhalb der 'pass' ausgeführt werden soll."
   },
-  "passff.prefs.shellArgs_label": {
+  "passff_prefs_shellArgs_label": {
     "message": "Shell Argumente"
   },
-  "passff.prefs.shellArgs_tooltip": {
+  "passff_prefs_shellArgs_tooltip": {
     "message": "Argumente, mit denen die Shell aufgerufen werden soll."
   },
-  "passff.prefs.home_label": {
+  "passff_prefs_home_label": {
     "message": "Benutzerverzeichnis"
   },
-  "passff.prefs.home_tooltip": {
+  "passff_prefs_home_tooltip": {
     "message": "Heimverzeichnis des Benutzers. Leer lassen für Nutzung der Umgebungsvariablen."
   },
-  "passff.prefs.gpg_agent_info_label": {
+  "passff_prefs_gpg_agent_info_label": {
     "message": "GPG-Agent-Info-Datei"
   },
-  "passff.prefs.gpg_agent_info_tooltip": {
+  "passff_prefs_gpg_agent_info_tooltip": {
     "message": "Speicherort der GPG_AGENT_INFO-Datei (Relativ zum Benutzerverzeichnis oder absolut). Wenn nicht gefunden wird versucht die Firefox-Umgebungsvariablen auszulesen."
   },
-  "passff.prefs.pass_dir_label": {
+  "passff_prefs_pass_dir_label": {
     "message": "Passwordstore-Ordner"
   },
-  "passff.prefs.pass_dir_tooltip": {
+  "passff_prefs_pass_dir_tooltip": {
     "message": "Passwordstore-Ordner (PASSWORD_STORE_DIR). Wenn leer wird die Umgebungsvariable PASSWORD_STORE_DIR genutzt."
   },
-  "passff.prefs.pass_git_label": {
+  "passff_prefs_pass_git_label": {
     "message": "Passwordstore Git-Ordner"
   },
-  "passff.prefs.pass_git_tooltip": {
+  "passff_prefs_pass_git_tooltip": {
     "message": "Passwordstore Git-Ordner (PASSWORD_STORE_GIT). Wenn leer wird die Umgebungsvariable PASSWORD_STORE_GIT genutzt."
   },
-  "passff.prefs.auto_fill_label": {
+  "passff_prefs_auto_fill_label": {
     "message": "Versuche, Loginseiten automatisch auszufüllen."
   },
-  "passff.prefs.auto_fill_tooltip": {
+  "passff_prefs_auto_fill_tooltip": {
     "message": "Wenn gesetzt wird automatisch versucht, Loginformulare auszufüllen indem ein Passwort entsprechend der Seiten-URL ausgewählt wird."
   },
-  "passff.prefs.auto_submit_label": {
+  "passff_prefs_auto_submit_label": {
     "message": "Versuche, Loginseiten automatisch abzusenden."
   },
-  "passff.prefs.auto_submit_tooltip": {
+  "passff_prefs_auto_submit_tooltip": {
     "message": "Wenn gesetzt wird automatisch versucht, Loginformulare abzusenden indem ein Passwort entsprechend der Seiten-URL ausgewählt wird."
   },
-  "passff.prefs.shortcut_key_label": {
+  "passff_prefs_shortcut_key_label": {
     "message": "Schnelltaste"
   },
-  "passff.prefs.shortcut_key_tooltip": {
+  "passff_prefs_shortcut_key_tooltip": {
     "message": "Die Schnelltaste, um das PassFF-Fenster zu öffnen."
   },
-  "passff.prefs.shortcut_mod_label": {
+  "passff_prefs_shortcut_mod_label": {
     "message": "Schnelltasten-Modifikatoren"
   },
-  "passff.prefs.shortcut_mod_tooltip": {
+  "passff_prefs_shortcut_mod_tooltip": {
     "message": "Die Modifikatoren-Tasten um das PassFF-Fenster zu öffnen. Eine Kombination aus den Worten 'control', 'alt' und 'shift', getrennt durch ein Komma."
   },
-  "passff.prefs.callmethod-tooltip": {
+  "passff_prefs_callmethod_tooltip": {
     "message": "Wähle aus, auf welche Art PassFF pass ausführen soll."
   },
-  "passff.prefs.callmethod": {
+  "passff_prefs_callmethod": {
     "message": "Aufrufmethode"
   },
-  "passff.prefs.direct_radio_label": {
+  "passff_prefs_direct_radio_label": {
     "message": "Direktaufruf"
   },
-  "passff.prefs.shell_radio_label": {
+  "passff_prefs_shell_radio_label": {
     "message": "über eine Shell"
   },
-  "passff.prefs.default_length_tooltip": {
+  "passff_prefs_default_length_tooltip": {
     "message": "Standardlänge für die Passwortgenerierung"
   },
-  "passff.prefs.default_length_label": {
+  "passff_prefs_default_length_label": {
     "message": "Standard Passwortlänge"
   },
-  "passff.prefs.default_include_symbols_tooltip": {
+  "passff_prefs_default_include_symbols_tooltip": {
     "message": "Sollen generierte Passwörter standardmäßig Symbole enthalten?"
   },
-  "passff.prefs.default_include_symbols_label": {
+  "passff_prefs_default_include_symbols_label": {
     "message": "Symbole standardmäßig verwenden"
   },
-  "passff.prefs.preferred_new_method_tooltip": {
+  "passff_prefs_preferred_new_method_tooltip": {
     "message": "Sollen neue Passwörter standardmäßig generiert oder eingetragen werden?"
   },
-  "passff.prefs.preferred_new_method_label": {
+  "passff_prefs_preferred_new_method_label": {
     "message": "Bevorzugte Methode"
   },
-  "passff.prefs.prefer_generate": {
+  "passff_prefs_prefer_generate": {
     "message": "Generieren"
   },
-  "passff.prefs.prefer_insert": {
+  "passff_prefs_prefer_insert": {
     "message": "Eintragen"
   },
-  "passff.newpassword.window.title": {
+  "passff_newpassword_window_title": {
     "message": "Neues Passwort"
   },
-  "passff.newpassword.window.header": {
+  "passff_newpassword_window_header": {
     "message": "Neues Passwort hinzufügen"
   },
-  "passff.newpassword.tabs.generate": {
+  "passff_newpassword_tabs_generate": {
     "message": "Generieren"
   },
-  "passff.newpassword.tabs.insert": {
+  "passff_newpassword_tabs_insert": {
     "message": "Eintragen"
   },
-  "passff.newpassword.inputs.password_name_label": {
+  "passff_newpassword_inputs_password_name_label": {
     "message": "Bezeichnung"
   },
-  "passff.newpassword.inputs.password_label": {
+  "passff_newpassword_inputs_password_label": {
     "message": "Passwort"
   },
-  "passff.newpassword.inputs.password_confirmation_label": {
+  "passff_newpassword_inputs_password_confirmation_label": {
     "message": "Passwort bestätigen"
   },
-  "passff.newpassword.inputs.additional_info_label": {
+  "passff_newpassword_inputs_additional_info_label": {
     "message": "Zusatzangaben"
   },
-  "passff.newpassword.inputs.password_length_label": {
+  "passff_newpassword_inputs_password_length_label": {
     "message": "Länge"
   },
-  "passff.newpassword.inputs.include_symbols_label": {
+  "passff_newpassword_inputs_include_symbols_label": {
     "message": "Symbole verwenden?"
   },
-  "passff.newpassword.inputs.add_password_button_label": {
+  "passff_newpassword_inputs_add_password_button_label": {
     "message": "Passwort hinzufügen"
   },
-  "passff.newpassword.inputs.generate_password_button_label": {
+  "passff_newpassword_inputs_generate_password_button_label": {
     "message": "Passwort generieren"
   },
-  "passff.newpassword.inputs.overwrite_password_prompt": {
+  "passff_newpassword_inputs_overwrite_password_prompt": {
     "message": "Dieses Passwort existiert bereits. Soll es wirklich überschrieben werden?"
   },
-  "passff.newpassword.errors.name_is_required": {
+  "passff_newpassword_errors_name_is_required": {
     "message": "Bezeichnung muss angegeben werden"
   },
-  "passff.newpassword.errors.password_is_required": {
+  "passff_newpassword_errors_password_is_required": {
     "message": "Passwort muss angegeben werden"
   },
-  "passff.newpassword.errors.password_confirmation_mismatch": {
+  "passff_newpassword_errors_password_confirmation_mismatch": {
     "message": "Passwortbestätigung stimmt nicht überein"
   },
-  "passff.newpassword.errors.pass_execution_failed": {
+  "passff_newpassword_errors_pass_execution_failed": {
     "message": "Ups, etwas ist schiefgegangen."
   },
-  "passff.newpassword.errors.unexpected_error": {
+  "passff_newpassword_errors_unexpected_error": {
     "message": "Ein unerwarteter Fehler ist aufgetreten."
   },
-  "passff.errors.unexpected_error": {
+  "passff_errors_unexpected_error": {
     "message": "Ein unerwarteter Fehler ist aufgetreten. Stellen Sie sicher, dass die Einstellungen korrekt sind und dass die Host-App installiert ist."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,288 +1,288 @@
 {
-  "passff.passphrase.title": {
+  "passff_passphrase_title": {
     "message": "Password repository locked"
   },
-  "passff.passphrase.description": {
+  "passff_passphrase_description": {
     "message": "Can't access to your password.\nPlease add your passphrase to gpg-agent first."
   },
-  "passff.menu.copy_password": {
+  "passff_menu_copy_password": {
     "message": "Copy password"
   },
-  "passff.menu.copy_login": {
+  "passff_menu_copy_login": {
     "message": "Copy login"
   },
-  "passff.menu.fill": {
+  "passff_menu_fill": {
     "message": "Fill"
   },
-  "passff.menu.fill_and_submit": {
+  "passff_menu_fill_and_submit": {
     "message": "Fill and submit"
   },
-  "passff.menu.goto_fill": {
+  "passff_menu_goto_fill": {
     "message": "Goto, fill"
   },
-  "passff.menu.goto_fill_and_submit": {
+  "passff_menu_goto_fill_and_submit": {
     "message": "Goto, fill and submit"
   },
-  "passff.menu.goto": {
+  "passff_menu_goto": {
     "message": "Goto"
   },
-  "passff.menu.display": {
+  "passff_menu_display": {
     "message": "Display"
   },
-  "passff.display.title": {
+  "passff_display_title": {
     "message": "Login/Password"
   },
-  "passff.display.description": {
+  "passff_display_description": {
     "message": "Login: $LOGIN$\n Password: $PASSWORD$",
     "placeholders": {
         "login": { "content": "$1" },
         "password": { "content": "$2" }
     }
   },
-  "passff.toolbar.button.label": {
+  "passff_toolbar_button_label": {
     "message": "PassFF"
   },
-  "passff.toolbar.search.placeholder": {
+  "passff_toolbar_search_placeholder": {
     "message": "Search"
   },
-  "passff.toolbar.refresh.label": {
+  "passff_toolbar_refresh_label": {
     "message": "Refresh"
   },
-  "passff.toolbar.preferences.label": {
+  "passff_toolbar_preferences_label": {
     "message": "Preferences"
   },
-  "passff.toolbar.new_password.label": {
+  "passff_toolbar_new_password_label": {
     "message": "New"
   },
-  "passff.button.root.label": {
+  "passff_button_root_label": {
     "message": "Display root"
   },
-  "passff.button.context.label": {
+  "passff_button_context_label": {
     "message": "Display contextual"
   },
-  "passff.prefs.tab.general": {
+  "passff_prefs_tab_general": {
     "message": "General"
   },
-  "passff.prefs.tab.autofilling": {
+  "passff_prefs_tab_autofilling": {
     "message": "Autofilling"
   },
-  "passff.prefs.tab.fields": {
+  "passff_prefs_tab_fields": {
     "message": "Fields"
   },
-  "passff.prefs.tab.script": {
+  "passff_prefs_tab_script": {
     "message": "Pass Script"
   },
-  "passff.prefs.tab.adding": {
+  "passff_prefs_tab_adding": {
     "message": "Adding Passwords"
   },
-  "passff.prefs.case-insensitive-search": {
+  "passff_prefs_case_insensitive_search": {
     "message": "Case-insensitive searching"
   },
-  "passff.prefs.case-insensitive-search-tooltip": {
+  "passff_prefs_case_insensitive_search_tooltip": {
     "message": "This will treat upper- and lowercase characters the same when searching for pass files"
   },
-  "passff.prefs.enter-behavior": {
+  "passff_prefs_enter_behavior": {
     "message": "Behavior of enter key"
   },
-  "passff.prefs.enter-behavior-tooltip": {
+  "passff_prefs_enter_behavior_tooltip": {
     "message": "This determines the default behavior when pressing the enter key on an item in the menu"
   },
-  "passff.prefs.fields_description": {
+  "passff_prefs_fields_description": {
     "message": "Fields are used to find data inside your passwords repository. PassFF will try to find the login, password or url value inside the password data (using the standard syntax) or trying to find a matching child node name"
   },
-  "passff.prefs.password_input_names_label": {
+  "passff_prefs_password_input_names_label": {
     "message": "Password input names"
   },
-  "passff.prefs.password_input_names_tooltip": {
+  "passff_prefs_password_input_names_tooltip": {
     "message": "Comma separated list of input names. Input field names in a html page containing one of those values will be filled with the password"
   },
-  "passff.prefs.login_input_names_label": {
+  "passff_prefs_login_input_names_label": {
     "message": "Login input names"
   },
-  "passff.prefs.login_input_names_tooltip": {
+  "passff_prefs_login_input_names_tooltip": {
     "message": "Comma separated list of input names. Input field names in a html page containing one of those values will be filled with the login"
   },
-  "passff.prefs.login_field_names_label": {
+  "passff_prefs_login_field_names_label": {
     "message": "Login field names"
   },
-  "passff.prefs.login_field_names_tooltip": {
+  "passff_prefs_login_field_names_tooltip": {
     "message": "Comma separated list of field names. The first matching field in the password data will be used as login"
   },
-  "passff.prefs.password_field_names_label": {
+  "passff_prefs_password_field_names_label": {
     "message": "Password field names"
   },
-  "passff.prefs.password_field_names_tooltip": {
+  "passff_prefs_password_field_names_tooltip": {
     "message": "Comma separated list of field names. The first matching field in the password data will be used as password"
   },
-  "passff.prefs.url_field_names_label": {
+  "passff_prefs_url_field_names_label": {
     "message": "Url field names"
   },
-  "passff.prefs.url_field_names_tooltip": {
+  "passff_prefs_url_field_names_tooltip": {
     "message": "Comma separated list of field names. The first matching field in the password data will be used as url"
   },
-  "passff.prefs.command_label": {
+  "passff_prefs_command_label": {
     "message": "Pass command"
   },
-  "passff.prefs.command_tooltip": {
+  "passff_prefs_command_tooltip": {
     "message": "The pass script path"
   },
-  "passff.prefs.commandArgs_label": {
+  "passff_prefs_commandArgs_label": {
     "message": "Arguments"
   },
-  "passff.prefs.commandArgs_tooltip": {
+  "passff_prefs_commandArgs_tooltip": {
     "message": "Arguments to pass to the pass script when run"
   },
-  "passff.prefs.shell_label": {
+  "passff_prefs_shell_label": {
     "message": "Pass shell"
   },
-  "passff.prefs.shell_tooltip": {
+  "passff_prefs_shell_tooltip": {
     "message": "The shell to use"
   },
-  "passff.prefs.shellArgs_label": {
+  "passff_prefs_shellArgs_label": {
     "message": "Shell arguments"
   },
-  "passff.prefs.shellArgs_tooltip": {
+  "passff_prefs_shellArgs_tooltip": {
     "message": "Arguments to start the shell with"
   },
-  "passff.prefs.home_label": {
+  "passff_prefs_home_label": {
     "message": "User home"
   },
-  "passff.prefs.home_tooltip": {
+  "passff_prefs_home_tooltip": {
     "message": "User home. If empty, use environment user home"
   },
-  "passff.prefs.gpg_agent_info_label": {
+  "passff_prefs_gpg_agent_info_label": {
     "message": "Gpg agent info file"
   },
-  "passff.prefs.gpg_agent_info_tooltip": {
+  "passff_prefs_gpg_agent_info_tooltip": {
     "message": "Location of the gpg agent info file containing environment variables (relative to the user home or absolute). if not found, try to load variables from firefox environment"
   },
-  "passff.prefs.pass_dir_label": {
+  "passff_prefs_pass_dir_label": {
     "message": "Pass store dir"
   },
-  "passff.prefs.pass_dir_tooltip": {
+  "passff_prefs_pass_dir_tooltip": {
     "message": "Pass store dir (PASSWORD_STORE_DIR). If empty, use the current environment PASSWORD_STORE_DIR"
   },
-  "passff.prefs.pass_git_label": {
+  "passff_prefs_pass_git_label": {
     "message": "Pass store git dir"
   },
-  "passff.prefs.pass_git_tooltip": {
+  "passff_prefs_pass_git_tooltip": {
     "message": "Pass store git dir (PASSWORD_STORE_GIT). If empty, use the current environment PASSWORD_STORE_GIT"
   },
-  "passff.prefs.auto_fill_label": {
+  "passff_prefs_auto_fill_label": {
     "message": "Try to auto fill page login forms"
   },
-  "passff.prefs.auto_fill_tooltip": {
+  "passff_prefs_auto_fill_tooltip": {
     "message": "If set, will try to fill automatically the login forms searching a password key contained in the page url"
   },
-  "passff.prefs.auto_submit_label": {
+  "passff_prefs_auto_submit_label": {
     "message": "Try to auto submit page login forms"
   },
-  "passff.prefs.auto_submit_tooltip": {
+  "passff_prefs_auto_submit_tooltip": {
     "message": "If set, will try to submit automatically the login forms searching a password key contained in the page url"
   },
-  "passff.prefs.shortcut_key_label": {
+  "passff_prefs_shortcut_key_label": {
     "message": "Shortcut key"
   },
-  "passff.prefs.shortcut_key_tooltip": {
+  "passff_prefs_shortcut_key_tooltip": {
     "message": "The shortcut key used to open the PassFF panel"
   },
-  "passff.prefs.shortcut_mod_label": {
+  "passff_prefs_shortcut_mod_label": {
     "message": "Shortcut modifier"
   },
-  "passff.prefs.shortcut_mod_tooltip": {
+  "passff_prefs_shortcut_mod_tooltip": {
     "message": "The shortcut modifiers used to open the PassFF panel. A combination of (control, alt, shift) words separated by a comma (,)"
   },
-  "passff.prefs.callmethod-tooltip": {
+  "passff_prefs_callmethod_tooltip": {
     "message": "Choose the method passff will use to run the pass script"
   },
-  "passff.prefs.callmethod": {
+  "passff_prefs_callmethod": {
     "message": "Script call method"
   },
-  "passff.prefs.direct_radio_label": {
+  "passff_prefs_direct_radio_label": {
     "message": "Direct call"
   },
-  "passff.prefs.shell_radio_label": {
+  "passff_prefs_shell_radio_label": {
     "message": "Through shell"
   },
-  "passff.prefs.default_length_tooltip": {
+  "passff_prefs_default_length_tooltip": {
     "message": "The default value for the length of a generated password"
   },
-  "passff.prefs.default_length_label": {
+  "passff_prefs_default_length_label": {
     "message": "Default password length"
   },
-  "passff.prefs.default_include_symbols_tooltip": {
+  "passff_prefs_default_include_symbols_tooltip": {
     "message": "Whether generated passwords should include symbols by default"
   },
-  "passff.prefs.default_include_symbols_label": {
+  "passff_prefs_default_include_symbols_label": {
     "message": "Include symbols by default"
   },
-  "passff.prefs.preferred_new_method_tooltip": {
+  "passff_prefs_preferred_new_method_tooltip": {
     "message": "Whether new passwords default to being generated or being inserted"
   },
-  "passff.prefs.preferred_new_method_label": {
+  "passff_prefs_preferred_new_method_label": {
     "message": "Preferred new method"
   },
-  "passff.prefs.prefer_generate": {
+  "passff_prefs_prefer_generate": {
     "message": "Generate"
   },
-  "passff.prefs.prefer_insert": {
+  "passff_prefs_prefer_insert": {
     "message": "Insert"
   },
-  "passff.newpassword.window.title": {
+  "passff_newpassword_window_title": {
     "message": "New Password"
   },
-  "passff.newpassword.window.header": {
+  "passff_newpassword_window_header": {
     "message": "Add a new password"
   },
-  "passff.newpassword.tabs.generate": {
+  "passff_newpassword_tabs_generate": {
     "message": "Generate"
   },
-  "passff.newpassword.tabs.insert": {
+  "passff_newpassword_tabs_insert": {
     "message": "Insert"
   },
-  "passff.newpassword.inputs.password_name_label": {
+  "passff_newpassword_inputs_password_name_label": {
     "message": "Name"
   },
-  "passff.newpassword.inputs.password_label": {
+  "passff_newpassword_inputs_password_label": {
     "message": "Password"
   },
-  "passff.newpassword.inputs.password_confirmation_label": {
+  "passff_newpassword_inputs_password_confirmation_label": {
     "message": "Confirm password"
   },
-  "passff.newpassword.inputs.additional_info_label": {
+  "passff_newpassword_inputs_additional_info_label": {
     "message": "Additional info"
   },
-  "passff.newpassword.inputs.password_length_label": {
+  "passff_newpassword_inputs_password_length_label": {
     "message": "Length"
   },
-  "passff.newpassword.inputs.include_symbols_label": {
+  "passff_newpassword_inputs_include_symbols_label": {
     "message": "Include symbols?"
   },
-  "passff.newpassword.inputs.add_password_button_label": {
+  "passff_newpassword_inputs_add_password_button_label": {
     "message": "Insert password"
   },
-  "passff.newpassword.inputs.generate_password_button_label": {
+  "passff_newpassword_inputs_generate_password_button_label": {
     "message": "Generate password"
   },
-  "passff.newpassword.inputs.overwrite_password_prompt": {
+  "passff_newpassword_inputs_overwrite_password_prompt": {
     "message": "That password already exists. Are you sure you want to overwrite it?"
   },
-  "passff.newpassword.errors.name_is_required": {
+  "passff_newpassword_errors_name_is_required": {
     "message": "Name must be present"
   },
-  "passff.newpassword.errors.password_is_required": {
+  "passff_newpassword_errors_password_is_required": {
     "message": "Password must be present"
   },
-  "passff.newpassword.errors.password_confirmation_mismatch": {
+  "passff_newpassword_errors_password_confirmation_mismatch": {
     "message": "Password confirmation doesn't match"
   },
-  "passff.newpassword.errors.pass_execution_failed": {
+  "passff_newpassword_errors_pass_execution_failed": {
     "message": "Oops, something went wrong"
   },
-  "passff.newpassword.errors.unexpected_error": {
+  "passff_newpassword_errors_unexpected_error": {
     "message": "Sorry, an unexpected error occurred"
   },
-  "passff.errors.unexpected_error": {
+  "passff_errors_unexpected_error": {
     "message": "Sorry, an unexpected error occured. Make sure your preferences are correctly set and that the native host app is installed."
   }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,288 +1,288 @@
 {
-  "passff.passphrase.title": {
+  "passff_passphrase_title": {
     "message": "Репозиторий паролей заблокирован"
   },
-  "passff.passphrase.description": {
+  "passff_passphrase_description": {
     "message": "Нет доступа к паролю.\n Сначала добавьте пароль в gpg-agent."
   },
-  "passff.menu.copy_password": {
+  "passff_menu_copy_password": {
     "message": "Копировать пароль"
   },
-  "passff.menu.copy_login": {
+  "passff_menu_copy_login": {
     "message": "Копировать логин"
   },
-  "passff.menu.fill": {
+  "passff_menu_fill": {
     "message": "Заполнить"
   },
-  "passff.menu.fill_and_submit": {
+  "passff_menu_fill_and_submit": {
     "message": "Заполнить и отправить"
   },
-  "passff.menu.goto_fill": {
+  "passff_menu_goto_fill": {
     "message": "Перейти и заполнить"
   },
-  "passff.menu.goto_fill_and_submit": {
+  "passff_menu_goto_fill_and_submit": {
     "message": "Перейти, заполнить и отправить"
   },
-  "passff.menu.goto": {
+  "passff_menu_goto": {
     "message": "Перейти"
   },
-  "passff.menu.display": {
+  "passff_menu_display": {
     "message": "Отобразить"
   },
-  "passff.display.title": {
+  "passff_display_title": {
     "message": "Логин/Пароль"
   },
-  "passff.display.description": {
+  "passff_display_description": {
     "message": "Логин: $LOGIN$\n Пароль: $PASSWORD$",
     "placeholders": {
         "login": { "content": "$1" },
         "password": { "content": "$2" }
     }
   },
-  "passff.toolbar.button.label": {
+  "passff_toolbar_button_label": {
     "message": "PassFF"
   },
-  "passff.toolbar.search.placeholder": {
+  "passff_toolbar_search_placeholder": {
     "message": "Поиск"
   },
-  "passff.toolbar.refresh.label": {
+  "passff_toolbar_refresh_label": {
     "message": "Обновить"
   },
-  "passff.toolbar.preferences.label": {
+  "passff_toolbar_preferences_label": {
     "message": "Настройки"
   },
-  "passff.toolbar.new_password.label": {
+  "passff_toolbar_new_password_label": {
     "message": "Новый"
   },
-  "passff.button.root.label": {
+  "passff_button_root_label": {
     "message": "Показать все"
   },
-  "passff.button.context.label": {
+  "passff_button_context_label": {
     "message": "Показать совпадения"
   },
-  "passff.prefs.tab.general": {
+  "passff_prefs_tab_general": {
     "message": "Общие"
   },
-  "passff.prefs.tab.autofilling": {
+  "passff_prefs_tab_autofilling": {
     "message": "Автозаполнение"
   },
-  "passff.prefs.tab.fields": {
+  "passff_prefs_tab_fields": {
     "message": "Поля"
   },
-  "passff.prefs.tab.script": {
+  "passff_prefs_tab_script": {
     "message": "Скрипт pass"
   },
-  "passff.prefs.tab.adding": {
+  "passff_prefs_tab_adding": {
     "message": "Добавление паролей"
   },
-  "passff.prefs.case-insensitive-search": {
+  "passff_prefs_case_insensitive_search": {
     "message": "Поиск без учета регистра"
   },
-  "passff.prefs.case-insensitive-search-tooltip": {
+  "passff_prefs_case_insensitive_search_tooltip": {
     "message": "Строчные и прописные буквы будут считатся одинаковыми при поиске файлов с паролями"
   },
-  "passff.prefs.enter-behavior": {
+  "passff_prefs_enter_behavior": {
     "message": "Поведение клавиши ввода"
   },
-  "passff.prefs.enter-behavior-tooltip": {
+  "passff_prefs_enter_behavior_tooltip": {
     "message": "Определяет поведение по умолчанию при нажатии клавиши ввода на элементе меню"
   },
-  "passff.prefs.fields_description": {
+  "passff_prefs_fields_description": {
     "message": "Поля которые используются для поиска данных в вашем репозитории паролей. PassFF пытается найти логин, пароль и адреса сайтов в файлах с паролями (используя стандартный синтаксис)."
   },
-  "passff.prefs.password_input_names_label": {
+  "passff_prefs_password_input_names_label": {
     "message": "Имена полей для паролей"
   },
-  "passff.prefs.password_input_names_tooltip": {
+  "passff_prefs_password_input_names_tooltip": {
     "message": "Список имен разделенных запятой. Поля с html-атрибутом 'name' равным одному из значений из этого списка будут заполнены паролями"
   },
-  "passff.prefs.login_input_names_label": {
+  "passff_prefs_login_input_names_label": {
     "message": "Имена полей для логинов"
   },
-  "passff.prefs.login_input_names_tooltip": {
+  "passff_prefs_login_input_names_tooltip": {
     "message": "Список имен разделенных запятой. Поля с html-атрибутом 'name' равным одному из значений из этого списка будут заполнены логинами"
   },
-  "passff.prefs.login_field_names_label": {
+  "passff_prefs_login_field_names_label": {
     "message": "Имена полей для логинов"
   },
-  "passff.prefs.login_field_names_tooltip": {
+  "passff_prefs_login_field_names_tooltip": {
     "message": "Список имен разделенных запятой. Содержимое первого найденого поля будет использоватся в качесте логина"
   },
-  "passff.prefs.password_field_names_label": {
+  "passff_prefs_password_field_names_label": {
     "message": "Имена полей для паролей"
   },
-  "passff.prefs.password_field_names_tooltip": {
+  "passff_prefs_password_field_names_tooltip": {
     "message": "Список имен разделенных запятой. Содержимое первого найденого поля будет использоватся в качесте пароля"
   },
-  "passff.prefs.url_field_names_label": {
+  "passff_prefs_url_field_names_label": {
     "message": "Имена полей для адресов сайтов"
   },
-  "passff.prefs.url_field_names_tooltip": {
+  "passff_prefs_url_field_names_tooltip": {
     "message": "Список имен разделенных запятой. Содержимое первого найденого поля будет использоватся в качесте адреса сайта"
   },
-  "passff.prefs.command_label": {
+  "passff_prefs_command_label": {
     "message": "Команда для запуска pass"
   },
-  "passff.prefs.command_tooltip": {
+  "passff_prefs_command_tooltip": {
     "message": "Команда для запуска pass"
   },
-  "passff.prefs.commandArgs_label": {
+  "passff_prefs_commandArgs_label": {
     "message": "Аргументы"
   },
-  "passff.prefs.commandArgs_tooltip": {
+  "passff_prefs_commandArgs_tooltip": {
     "message": "Аргументы для скрипта"
   },
-  "passff.prefs.shell_label": {
+  "passff_prefs_shell_label": {
     "message": "Командная оболочка"
   },
-  "passff.prefs.shell_tooltip": {
+  "passff_prefs_shell_tooltip": {
     "message": "Используемая командная оболочка"
   },
-  "passff.prefs.shellArgs_label": {
+  "passff_prefs_shellArgs_label": {
     "message": "Аргументы для командной оболочки"
   },
-  "passff.prefs.shellArgs_tooltip": {
+  "passff_prefs_shellArgs_tooltip": {
     "message": "Аргументы используемые при запуске командной оболочки"
   },
-  "passff.prefs.home_label": {
+  "passff_prefs_home_label": {
     "message": "Домашняя директория"
   },
-  "passff.prefs.home_tooltip": {
+  "passff_prefs_home_tooltip": {
     "message": "Домашняя директория. Если поле пустое, используется системная переменная HOME"
   },
-  "passff.prefs.gpg_agent_info_label": {
+  "passff_prefs_gpg_agent_info_label": {
     "message": "Файл info для gpg-агента"
   },
-  "passff.prefs.gpg_agent_info_tooltip": {
+  "passff_prefs_gpg_agent_info_tooltip": {
     "message": "Путь к info-файлу для gpg-agent с переменными окружения (относительный или полный), если он не будет нйден, будут использоватся переменные из окружения Firefox"
   },
-  "passff.prefs.pass_dir_label": {
+  "passff_prefs_pass_dir_label": {
     "message": "Директория с паролями для pass"
   },
-  "passff.prefs.pass_dir_tooltip": {
+  "passff_prefs_pass_dir_tooltip": {
     "message": "Директория с паролями для pass (PASSWORD_STORE_DIR). Если поле пустое, используется системная переменная PASSWORD_STORE_DIR"
   },
-  "passff.prefs.pass_git_label": {
+  "passff_prefs_pass_git_label": {
     "message": "Директория git с паролями для pass"
   },
-  "passff.prefs.pass_git_tooltip": {
+  "passff_prefs_pass_git_tooltip": {
     "message": "Директория git с паролями для pass (PASSWORD_STORE_GIT). Если поле пустое, используется системная переменная PASSWORD_STORE_GIT"
   },
-  "passff.prefs.auto_fill_label": {
+  "passff_prefs_auto_fill_label": {
     "message": "Автоматически заполнять поля для входа"
   },
-  "passff.prefs.auto_fill_tooltip": {
+  "passff_prefs_auto_fill_tooltip": {
     "message": "Если включено тогда автоматически заполнять поля для входа"
   },
-  "passff.prefs.auto_submit_label": {
+  "passff_prefs_auto_submit_label": {
     "message": "Автоматически отправлять поля для входа"
   },
-  "passff.prefs.auto_submit_tooltip": {
+  "passff_prefs_auto_submit_tooltip": {
     "message": "Если включено тогда автоматически заполнять и отправлять данные для входа из файла с паролями"
   },
-  "passff.prefs.shortcut_key_label": {
+  "passff_prefs_shortcut_key_label": {
     "message": "Быстрая клавиша"
   },
-  "passff.prefs.shortcut_key_tooltip": {
+  "passff_prefs_shortcut_key_tooltip": {
     "message": "Быстрая клавиша используемая для открытия окна PassFF"
   },
-  "passff.prefs.shortcut_mod_label": {
+  "passff_prefs_shortcut_mod_label": {
     "message": "Модификаторы для быстрой клавиши"
   },
-  "passff.prefs.shortcut_mod_tooltip": {
+  "passff_prefs_shortcut_mod_tooltip": {
     "message": "Модификаторы для быстрой клавиши используемые для открытия окна PassFF. Комбинация из (Control, Alt, Shift) и других символов разделенных запятой (,)"
   },
-  "passff.prefs.callmethod-tooltip": {
+  "passff_prefs_callmethod_tooltip": {
     "message": "Выберите метод который будет использоватся для запуска скрипта"
   },
-  "passff.prefs.callmethod": {
+  "passff_prefs_callmethod": {
     "message": "Метод запуска скрипта"
   },
-  "passff.prefs.direct_radio_label": {
+  "passff_prefs_direct_radio_label": {
     "message": "Прямой запуск"
   },
-  "passff.prefs.shell_radio_label": {
+  "passff_prefs_shell_radio_label": {
     "message": "Используя командную оболочку"
   },
-  "passff.prefs.default_length_tooltip": {
+  "passff_prefs_default_length_tooltip": {
     "message": "Длина пароля по умолчанию"
   },
-  "passff.prefs.default_length_label": {
+  "passff_prefs_default_length_label": {
     "message": "Длина пароля по умолчанию"
   },
-  "passff.prefs.default_include_symbols_tooltip": {
+  "passff_prefs_default_include_symbols_tooltip": {
     "message": "Должны ли сгенерированные пароли использовать отличные от букв и цифр символы"
   },
-  "passff.prefs.default_include_symbols_label": {
+  "passff_prefs_default_include_symbols_label": {
     "message": "Включать все символы по умолчанию"
   },
-  "passff.prefs.preferred_new_method_tooltip": {
+  "passff_prefs_preferred_new_method_tooltip": {
     "message": "Генерировать или вставлять новые пароли"
   },
-  "passff.prefs.preferred_new_method_label": {
+  "passff_prefs_preferred_new_method_label": {
     "message": "Предпочтительный новый метод"
   },
-  "passff.prefs.prefer_generate": {
+  "passff_prefs_prefer_generate": {
     "message": "Сгенерировать"
   },
-  "passff.prefs.prefer_insert": {
+  "passff_prefs_prefer_insert": {
     "message": "Вставить"
   },
-  "passff.newpassword.window.title": {
+  "passff_newpassword_window_title": {
     "message": "Новый пароль"
   },
-  "passff.newpassword.window.header": {
+  "passff_newpassword_window_header": {
     "message": "Добавить новый пароль"
   },
-  "passff.newpassword.tabs.generate": {
+  "passff_newpassword_tabs_generate": {
     "message": "Генерировать"
   },
-  "passff.newpassword.tabs.insert": {
+  "passff_newpassword_tabs_insert": {
     "message": "Вставить"
   },
-  "passff.newpassword.inputs.password_name_label": {
+  "passff_newpassword_inputs_password_name_label": {
     "message": "Имя"
   },
-  "passff.newpassword.inputs.password_label": {
+  "passff_newpassword_inputs_password_label": {
     "message": "Пароль"
   },
-  "passff.newpassword.inputs.password_confirmation_label": {
+  "passff_newpassword_inputs_password_confirmation_label": {
     "message": "Подтвердить пароль"
   },
-  "passff.newpassword.inputs.additional_info_label": {
+  "passff_newpassword_inputs_additional_info_label": {
     "message": "Дополнительные данные"
   },
-  "passff.newpassword.inputs.password_length_label": {
+  "passff_newpassword_inputs_password_length_label": {
     "message": "Длинна"
   },
-  "passff.newpassword.inputs.include_symbols_label": {
+  "passff_newpassword_inputs_include_symbols_label": {
     "message": "Включая отличные от букв и цифр символы?"
   },
-  "passff.newpassword.inputs.add_password_button_label": {
+  "passff_newpassword_inputs_add_password_button_label": {
     "message": "Вставить пароль"
   },
-  "passff.newpassword.inputs.generate_password_button_label": {
+  "passff_newpassword_inputs_generate_password_button_label": {
     "message": "Генерировать пароль"
   },
-  "passff.newpassword.inputs.overwrite_password_prompt": {
+  "passff_newpassword_inputs_overwrite_password_prompt": {
     "message": "Пароль уже есть. Хотите ли вы его надписать?"
   },
-  "passff.newpassword.errors.name_is_required": {
+  "passff_newpassword_errors_name_is_required": {
     "message": "Имя обязательно"
   },
-  "passff.newpassword.errors.password_is_required": {
+  "passff_newpassword_errors_password_is_required": {
     "message": "Пароль обязателен"
   },
-  "passff.newpassword.errors.password_confirmation_mismatch": {
+  "passff_newpassword_errors_password_confirmation_mismatch": {
     "message": "Пароли не сходятся"
   },
-  "passff.newpassword.errors.pass_execution_failed": {
+  "passff_newpassword_errors_pass_execution_failed": {
     "message": "Ой, чтото пошло не так"
   },
-  "passff.newpassword.errors.unexpected_error": {
+  "passff_newpassword_errors_unexpected_error": {
     "message": "Извините, произошла неожиданная ошибка"
   },
-  "passff.errors.unexpected_error": {
+  "passff_errors_unexpected_error": {
     "message": "Извините, произошла неожиданная ошибка. Убедитесь что ваши установки правильны и что нативная программа заинстлирована в операционной системе."
   }
 }

--- a/src/content/newPasswordWindow.html
+++ b/src/content/newPasswordWindow.html
@@ -9,19 +9,19 @@
     <div class="tabbox">
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab0">
-        <label for="tab0">passff.newpassword.tabs.generate</label>
+        <label for="tab0">passff_newpassword_tabs_generate</label>
         <fieldset>
           <p>
-            <label>passff.newpassword.inputs.password_name_label</label>
+            <label>passff_newpassword_inputs_password_name_label</label>
             <input type="text" id="gen-password-name" value="" />
           </p><p>
-            <label>passff.newpassword.inputs.password_length_label</label>
+            <label>passff_newpassword_inputs_password_length_label</label>
             <input type="text" id="gen-password-length" value="16" />
           </p><p>
-            <label>passff.newpassword.inputs.include_symbols_label</label>
+            <label>passff_newpassword_inputs_include_symbols_label</label>
             <input type="checkbox" id="gen-include-symbols" checked="true" />
           </p><p>
-            <button id="gen-save-button">passff.newpassword.inputs.generate_password_button_label</button>
+            <button id="gen-save-button">passff_newpassword_inputs_generate_password_button_label</button>
           </p>
           <div id="gen-errors-container"></div>
         </fieldset>
@@ -29,22 +29,22 @@
 
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab1" checked="checked">
-        <label for="tab1">passff.newpassword.tabs.insert</label>
+        <label for="tab1">passff_newpassword_tabs_insert</label>
         <fieldset>
           <p>
-            <label>passff.newpassword.inputs.password_name_label</label>
+            <label>passff_newpassword_inputs_password_name_label</label>
             <input type="text" id="add-password-name" value="" />
           </p><p>
-            <label>passff.newpassword.inputs.password_label</label>
+            <label>passff_newpassword_inputs_password_label</label>
             <input type="password" id="add-password" value="" />
           </p><p>
-            <label>passff.newpassword.inputs.password_confirmation_label</label>
+            <label>passff_newpassword_inputs_password_confirmation_label</label>
             <input type="password" id="add-password-confirmation" value="" />
           </p><p>
-            <label>passff.newpassword.inputs.additional_info_label</label>
+            <label>passff_newpassword_inputs_additional_info_label</label>
             <textarea id="add-additional-info"></textarea>
           </p><p>
-            <button id="save-button">passff.newpassword.inputs.add_password_button_label</button>
+            <button id="save-button">passff_newpassword_inputs_add_password_button_label</button>
           </p>
           <div id="add-errors-container"></div>
         </fieldset>

--- a/src/content/newPasswordWindow.js
+++ b/src/content/newPasswordWindow.js
@@ -2,7 +2,7 @@
 'use strict';
 
 function _(msg_id) {
-    return PassFF.gsfm("passff.newpassword." + msg_id);
+    return PassFF.gsfm("passff_newpassword_" + msg_id);
 }
 
 function isPresent(field, errorMsg) {

--- a/src/content/preferencesWindow.html
+++ b/src/content/preferencesWindow.html
@@ -8,24 +8,24 @@
     <div class="tabbox">
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab0" checked="checked">
-        <label for="tab0">passff.prefs.tab.general</label>
+        <label for="tab0">passff_prefs_tab_general</label>
         <fieldset>
           <p>
-            <label>passff.prefs.shortcut_mod_label</label>
+            <label>passff_prefs_shortcut_mod_label</label>
             <input type="text" id="pref_shortcutMod" value="" />
           </p><p>
-            <label>passff.prefs.shortcut_key_label</label>
+            <label>passff_prefs_shortcut_key_label</label>
             <input type="text" id="pref_shortcutKey" value="" />
           </p><p>
-            <label>passff.prefs.case-insensitive-search</label>
+            <label>passff_prefs_case_insensitive_search</label>
             <input type="checkbox" id="pref_caseInsensitiveSearch" />
           </p><p>
-            <label>passff.prefs.enter-behavior</label>
+            <label>passff_prefs_enter_behavior</label>
             <select id="pref_enterBehavior">
-              <option value="0">passff.menu.goto_fill_and_submit</option>
-              <option value="1">passff.menu.goto_fill</option>
-              <option value="2">passff.menu.fill_and_submit</option>
-              <option value="3">passff.menu.fill</option>
+              <option value="0">passff_menu_goto_fill_and_submit</option>
+              <option value="1">passff_menu_goto_fill</option>
+              <option value="2">passff_menu_fill_and_submit</option>
+              <option value="3">passff_menu_fill</option>
             </select>
           </p>
         </fieldset>
@@ -33,19 +33,19 @@
 
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab1">
-        <label for="tab1">passff.prefs.tab.autofilling</label>
+        <label for="tab1">passff_prefs_tab_autofilling</label>
         <fieldset>
           <p>
-            <label>passff.prefs.auto_fill_label</label>
+            <label>passff_prefs_auto_fill_label</label>
             <input type="checkbox" id="pref_autoFill" />
           </p><p>
-            <label>passff.prefs.auto_submit_label</label>
+            <label>passff_prefs_auto_submit_label</label>
             <input type="checkbox" id="pref_autoSubmit" />
           </p><p>
-            <label>passff.prefs.password_input_names_label</label>
+            <label>passff_prefs_password_input_names_label</label>
             <input type="text" id="pref_passwordInputNames" value="" />
           </p><p>
-            <label>passff.prefs.login_input_names_label</label>
+            <label>passff_prefs_login_input_names_label</label>
             <input type="text" id="pref_loginInputNames" value="" />
           </p>
         </fieldset>
@@ -53,17 +53,17 @@
 
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab2">
-        <label for="tab2">passff.prefs.tab.fields</label>
+        <label for="tab2">passff_prefs_tab_fields</label>
         <fieldset>
-          <p class="text">passff.prefs.fields_description</p>
+          <p class="text">passff_prefs_fields_description</p>
           <p>
-            <label>passff.prefs.password_field_names_label</label>
+            <label>passff_prefs_password_field_names_label</label>
             <input type="text" id="pref_passwordFieldNames" value="" />
           </p><p>
-            <label>passff.prefs.login_field_names_label</label>
+            <label>passff_prefs_login_field_names_label</label>
             <input type="text" id="pref_loginFieldNames" value="" />
           </p><p>
-            <label>passff.prefs.url_field_names_label</label>
+            <label>passff_prefs_url_field_names_label</label>
             <input type="text" id="pref_urlFieldNames" value="" />
           </p>
         </fieldset>
@@ -71,39 +71,39 @@
 
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab3">
-        <label for="tab3">passff.prefs.tab.script</label>
+        <label for="tab3">passff_prefs_tab_script</label>
         <fieldset>
           <p>
-            <label>passff.prefs.home_label</label>
+            <label>passff_prefs_home_label</label>
             <input type="text" id="pref_home" value="" />
           </p><p>
-            <label>passff.prefs.command_label</label>
+            <label>passff_prefs_command_label</label>
             <input type="text" id="pref_command" value="" />
           </p><p>
-            <label>passff.prefs.commandArgs_label</label>
+            <label>passff_prefs_commandArgs_label</label>
             <input type="text" id="pref_commandArgs" value="" />
           </p><p>
-            <label>passff.prefs.callmethod</label>
+            <label>passff_prefs_callmethod</label>
             <input type="radio" id="pref_callType_shell"
                    name="pref_callType" value="shell" />
-              <label>passff.prefs.shell_radio_label</label>
+              <label>passff_prefs_shell_radio_label</label>
             <input type="radio" id="pref_callType_direct"
                    name="pref_callType" value="direct" />
-              <label>passff.prefs.direct_radio_label</label>
+              <label>passff_prefs_direct_radio_label</label>
           </p><p class="shell_radio">
-            <label>passff.prefs.shell_label</label>
+            <label>passff_prefs_shell_label</label>
             <input type="text" id="pref_shell" value="" />
           </p><p class="shell_radio">
-            <label>passff.prefs.shellArgs_label</label>
+            <label>passff_prefs_shellArgs_label</label>
             <input type="text" id="pref_shellArgs" value="" />
           </p><p class="direct_radio">
-            <label>passff.prefs.gpg_agent_info_label</label>
+            <label>passff_prefs_gpg_agent_info_label</label>
             <input type="text" id="pref_gpgAgentInfo" value="" />
           </p><p class="direct_radio">
-            <label>passff.prefs.pass_dir_label</label>
+            <label>passff_prefs_pass_dir_label</label>
             <input type="text" id="pref_storeDir" value="" />
           </p><p class="direct_radio">
-            <label>passff.prefs.pass_git_label</label>
+            <label>passff_prefs_pass_git_label</label>
             <input type="text" id="pref_storeGit" value="" />
           </p>
         </fieldset>
@@ -111,16 +111,16 @@
 
       <div class="tab">
         <input type="radio" name="tab_radio" id="tab4">
-        <label for="tab4">passff.prefs.tab.adding</label>
+        <label for="tab4">passff_prefs_tab_adding</label>
         <fieldset>
           <p>
-            <label>passff.prefs.default_length_label</label>
+            <label>passff_prefs_default_length_label</label>
             <input type="text" id="pref_defaultPasswordLength" value="" />
           </p><p>
-            <label>passff.prefs.default_include_symbols_label</label>
+            <label>passff_prefs_default_include_symbols_label</label>
             <input type="checkbox" id="pref_defaultIncludeSymbols" />
           </p><p>
-            <label>passff.prefs.preferred_new_method_label</label>
+            <label>passff_prefs_preferred_new_method_label</label>
             <input type="checkbox" id="pref_preferInsert" />
           </p>
         </fieldset>

--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -7,7 +7,7 @@
 let logAndDisplayError = (errorMessage) => {
   return (error) => {
     log.error(errorMessage, ":", error);
-    PassFF.Menu.addMessage(PassFF.gsfm("passff.errors.unexpected_error"));
+    PassFF.Menu.addMessage(PassFF.gsfm("passff_errors_unexpected_error"));
   };
 };
 
@@ -44,19 +44,19 @@ PassFF.Menu = {
     let searchBox = doc.querySelector('.searchbar input[type=text]');
     searchBox.setAttribute('id', PassFF.Ids.searchbox);
     searchBox.setAttribute('placeholder',
-                               PassFF.gsfm('passff.toolbar.search.placeholder'));
+                               PassFF.gsfm('passff_toolbar_search_placeholder'));
     searchBox.addEventListener('click', function (e) { e.target.select(); });
     searchBox.addEventListener('keypress', PassFF.Menu.onSearchKeypress);
     searchBox.addEventListener('keyup', PassFF.Menu.onSearchKeyup);
 
     let showAllButton = doc.querySelector('.actions div:nth-child(1) > button');
     showAllButton.setAttribute('id', PassFF.Ids.rootbutton);
-    showAllButton.textContent = PassFF.gsfm('passff.button.root.label');
+    showAllButton.textContent = PassFF.gsfm('passff_button_root_label');
     showAllButton.addEventListener('click', PassFF.Menu.onRootButtonCommand);
 
     let showMatchingButton = doc.querySelector('.actions div:nth-child(2) > button');
     showMatchingButton.setAttribute('id', PassFF.Ids.contextbutton);
-    showMatchingButton.textContent = PassFF.gsfm('passff.button.context.label');
+    showMatchingButton.textContent = PassFF.gsfm('passff_button_context_label');
     showMatchingButton.addEventListener('click', PassFF.Menu.onContextButtonCommand);
 
     let entryList = doc.querySelector('.results select');
@@ -65,17 +65,17 @@ PassFF.Menu = {
 
     let refreshButton = doc.querySelector('.actions button.reload');
     refreshButton.setAttribute('id', PassFF.Ids.refreshmenuitem);
-    refreshButton.setAttribute('title', PassFF.gsfm('passff.toolbar.refresh.label'));
+    refreshButton.setAttribute('title', PassFF.gsfm('passff_toolbar_refresh_label'));
     refreshButton.addEventListener('click', PassFF.Menu.onRefresh);
 
     let prefsButton = doc.querySelector('.actions button.config');
     prefsButton.setAttribute('id', PassFF.Ids.prefsmenuitem);
-    prefsButton.setAttribute('title', PassFF.gsfm('passff.toolbar.preferences.label'));
+    prefsButton.setAttribute('title', PassFF.gsfm('passff_toolbar_preferences_label'));
     prefsButton.addEventListener('click', PassFF.Menu.onPreferences);
 
     let newPasswordButton = doc.querySelector('.actions button.add');
     newPasswordButton.setAttribute('id', PassFF.Ids.newpasswordmenuitem);
-    newPasswordButton.setAttribute('title', PassFF.gsfm('passff.toolbar.new_password.label'));
+    newPasswordButton.setAttribute('title', PassFF.gsfm('passff_toolbar_new_password_label'));
     newPasswordButton.addEventListener('click', PassFF.Menu.onNewPassword);
 
     return panel;
@@ -370,13 +370,13 @@ PassFF.Menu = {
     log.debug('Create leaf menu list', item);
     let listElm = doc.getElementById(PassFF.Ids.entrieslist);
 
-    [ ['passff.menu.fill', PassFF.Menu.onAutoFillMenuClick],
-      ['passff.menu.fill_and_submit', PassFF.Menu.onAutoFillAndSubmitMenuClick],
-      ['passff.menu.goto_fill_and_submit', PassFF.Menu.onGotoAutoFillAndSubmitMenuClick],
-      ['passff.menu.goto', PassFF.Menu.onGoto],
-      ['passff.menu.copy_login', PassFF.Menu.onCopyToClipboard, 'login'],
-      ['passff.menu.copy_password', PassFF.Menu.onCopyToClipboard, 'password'],
-      ['passff.menu.display', PassFF.Menu.onDisplayItemData]
+    [ ['passff_menu_fill', PassFF.Menu.onAutoFillMenuClick],
+      ['passff_menu_fill_and_submit', PassFF.Menu.onAutoFillAndSubmitMenuClick],
+      ['passff_menu_goto_fill_and_submit', PassFF.Menu.onGotoAutoFillAndSubmitMenuClick],
+      ['passff_menu_goto', PassFF.Menu.onGoto],
+      ['passff_menu_copy_login', PassFF.Menu.onCopyToClipboard, 'login'],
+      ['passff_menu_copy_password', PassFF.Menu.onCopyToClipboard, 'password'],
+      ['passff_menu_display', PassFF.Menu.onDisplayItemData]
     ].forEach(function(data) {
       let newItem = PassFF.Menu.createMenuItem(doc, item, PassFF.gsfm(data[0]), data[1],
                                                data.length == 3 ? data[2] : undefined);

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -136,8 +136,8 @@ PassFF.Pass = {
                              .indexOf('gpg: decryption failed: No secret key') >= 0;
 
       while (executionResult.exitCode !== 0 && gpgDecryptFailed) {
-        let title = PassFF.gsfm('passff.passphrase.title');
-        let desc = PassFF.gsfm('passff.passphrase.description');
+        let title = PassFF.gsfm('passff_passphrase_title');
+        let desc = PassFF.gsfm('passff_passphrase_description');
         /* We skip this for now since we don't have 'window.confirm' ...
         if (!window.confirm(title + "\n" + desc)) {
           return;


### PR DESCRIPTION
I just replaced `-` and `.` with `_`, which is the only symbol allowed.

This isn't sufficient to work in Chromium (#105). It still complains that 'browser is not defined'.