### PR TITLE
remove input type checking from other fields

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -229,8 +229,7 @@ function isLoginInput(input) {
 
 function isOtherInputCheck(other) {
   return function(input) {
-    return (loginInputTypes.indexOf(input.type) >= 0 &&
-           hasGoodName(input.name ? input.name : input.id, Object.keys(other)));
+    return (hasGoodName(input.name ? input.name : input.id, Object.keys(other)));
   }
 }
 


### PR DESCRIPTION
Hi. Unfortunately I have to use some web-pages that have two input fields of type password. 

passff will fill the password from the first line of the password file into **all** html input fields that have the password type - regardless of the presence of correct <other_inputfield_name>: <inputfield_value> lines. This is because isOtherInputCheck test for the loginInputTypes.

I removed this check and now the forms are filled correctly. I cannot see any side-effects. In fact, I do not understand why the other fields should only be text, email or tel inputs.