### PR TITLE
Safer autofill

### DIFF
--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -131,7 +131,7 @@ PassFF.Pass = {
 
     if (item.isLeaf()) { // multiline-style item
       let args = [item.fullKey()];
-      return this.executePass(args).then((executionResult) => {
+      return this.executePass(args, {}, true).then((executionResult) => {
       if (executionResult.exitCode !== 0) {
         return;
       }
@@ -427,7 +427,7 @@ PassFF.Pass = {
     });
   },
 
-  executePass: function(args, subprocessOverrides) {
+  executePass: function(args, subprocessOverrides, blockFailAlert) {
     let result = null;
     let scriptArgs = [];
     let command = null;
@@ -478,7 +478,9 @@ PassFF.Pass = {
     log.debug('Execute pass', params);
     return browser.runtime.sendNativeMessage("passff", params).then((result) => {
       if (result.exitCode !== 0) {
-        PassFF.alert('pass execution failed!' + "\n" + result.stderr + "\n" + result.stdout);
+        if (!blockFailAlert) {
+          PassFF.alert('pass execution failed!' + "\n" + result.stderr + "\n" + result.stdout);
+        }
         log.warn('pass execution failed', result.exitCode, result.stderr, result.stdout);
       } else {
         log.info('pass script execution ok');

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -55,6 +55,7 @@ PassFF.Pass = {
   _items: [],
   _rootItems: [],
   _stringBundle: null,
+  _pending: {},
 
   env: {
     _environment: {},
@@ -126,12 +127,21 @@ PassFF.Pass = {
     }).bind(this));
   },
 
+  getPassExecPromise: function(key) {
+    if (!this._pending.hasOwnProperty(key))
+      this._pending[key] = this.executePass([key], {}, true).then((result) => {
+        delete this._pending[key];
+        return result;
+      });
+    return this._pending[key];
+  },
+
   getPasswordData: function(item) {
     let result = {};
 
     if (item.isLeaf()) { // multiline-style item
-      let args = [item.fullKey()];
-      return this.executePass(args, {}, true).then((executionResult) => {
+      let key = item.fullKey();
+      return this.getPassExecPromise(key).then((executionResult) => {
       if (executionResult.exitCode !== 0) {
         return;
       }

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -132,21 +132,6 @@ PassFF.Pass = {
     if (item.isLeaf()) { // multiline-style item
       let args = [item.fullKey()];
       return this.executePass(args).then((executionResult) => {
-      let gpgDecryptFailed = executionResult.stderr
-                             .indexOf('gpg: decryption failed: No secret key') >= 0;
-
-      while (executionResult.exitCode !== 0 && gpgDecryptFailed) {
-        let title = PassFF.gsfm('passff_passphrase_title');
-        let desc = PassFF.gsfm('passff_passphrase_description');
-        /* We skip this for now since we don't have 'window.confirm' ...
-        if (!window.confirm(title + "\n" + desc)) {
-          return;
-        }
-
-        executionResult = PassFF.Pass.executePass(args);
-        */
-      }
-
       if (executionResult.exitCode !== 0) {
         return;
       }


### PR DESCRIPTION
This PR:
* Keeps a map of running execPass calls to prevent starving the gpg-agent with multiple overlapping requests for the same password. On my system, this dramatically reduces the number of duplicate passphrase prompts I receive.
* Suppresses the usual `window.alert` on `pass` failure when called from `getPasswordData`, which would fight with the gpg-agent passphrase dialog for focus and cause the UI to become unresponsive.
* Removes the infinite loop that caused passff to freeze the browser when the `No secret key` error occurs.

Tested against FF Nightly 59.0a1 (2017-11-19) (64-bit) on ArchLinux.

It is believed this PR will close #220, #243 and #101.