### PR TITLE
Add some DOM trickery to let the keyboard shortcut through, even when a password entry field is focused.

### DIFF
--- a/src/modules/main.js
+++ b/src/modules/main.js
@@ -137,6 +137,67 @@ var PassFF = {
     let items = PassFF.Pass.getUrlMatchingItems(PassFF.tab_url);
     PassFF.menu_state.items = items.map((i) => { return i.toObject(true); });
     PassFF.Page.tabAutoFill(tab);
+
+    // Allow our browser command to bypass the usual dom event mapping, so that
+    // Ctrl+Y still works, even  when a password field is focused.
+    browser.commands.getAll().then((commands) => {
+      // Mapping between modifier names in manifest.json and DOM KeyboardEvent.
+      let commandModifiers = {
+        'Ctrl': browser.runtime.PlatformOs == 'mac' ? 'Meta' : 'Control',
+        'MacCtrl': 'Cotrol',
+        'Command': 'Meta',
+        'Alt': 'Alt',
+        'Shift': 'Shift'
+      };
+
+      // Read the _execute_browser_action command to get its shortcut. We're
+      // ignoring the shortcut specified in preferences because there is
+      // currently no way to apply that preference. See open mozilla bug at
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1215061
+      var commandLetter = 'Y';
+      let expectedModifierState = {
+        'Alt': false,
+        'Meta': false,
+        'Cotrol': false,
+        'Shift': false
+      };
+
+      commands.forEach((command) => {
+        if ('_execute_browser_action' == command.name && command.shortcut) {
+          command.shortcut.split(/\s*\+\s*/).forEach((part) => {
+            if (commandModifiers.hasOwnProperty(part)) {
+              expectedModifierState[commandModifiers[part]] = true;
+            } else {
+              commandLetter = part.toLowerCase();
+            }
+          });
+        }
+      });
+
+      // Attach a DOM-level event handler for our command key, so it works
+      // even if an input box is focused.
+      browser.tabs.executeScript({
+        code: `
+          document.addEventListener('keydown', function(evt) {
+            let expectedModifierState = {0};
+            if ({1} == evt.key) {
+              for (var modifier in expectedModifierState)
+                if (expectedModifierState[modifier] !== \
+                    evt.getModifierState(modifier))
+                  return;
+
+              // This is a bit of a hack: if we focus the body on keydown,
+              // the DOM won't let the input box handle the keypress, and
+              // it'll get routed to _execute_browser_action instead.
+              document.firstElementChild.focus();
+            }
+          }, true);
+        `.format(
+          JSON.stringify(expectedModifierState),
+          JSON.stringify(commandLetter)
+        )
+      });
+    });
   },
 
   onTabUpdate: function () {

--- a/src/modules/main.js
+++ b/src/modules/main.js
@@ -176,7 +176,7 @@ var PassFF = {
 
       // Attach a DOM-level event handler for our command key, so it works
       // even if an input box is focused.
-      browser.tabs.executeScript({
+      browser.tabs.executeScript(tab, {
         code: `
           document.addEventListener('keydown', function(evt) {
             let expectedModifierState = {0};

--- a/src/modules/main.js
+++ b/src/modules/main.js
@@ -144,7 +144,7 @@ var PassFF = {
       // Mapping between modifier names in manifest.json and DOM KeyboardEvent.
       let commandModifiers = {
         'Ctrl': browser.runtime.PlatformOs == 'mac' ? 'Meta' : 'Control',
-        'MacCtrl': 'Cotrol',
+        'MacCtrl': 'Control',
         'Command': 'Meta',
         'Alt': 'Alt',
         'Shift': 'Shift'
@@ -158,7 +158,7 @@ var PassFF = {
       let expectedModifierState = {
         'Alt': false,
         'Meta': false,
-        'Cotrol': false,
+        'Control': false,
         'Shift': false
       };
 


### PR DESCRIPTION
This PR is intended to close #225. 

As requested in that issue, this commit attempts future-proofing against the eventual solution to [the configurable keyboard shortcuts Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1215061). 

The central idea is to blur any focused text entry fields on `keydown` so they can't swallow the `keypress` that would otherwise trigger the passff UI. Most of the logic involved is in calculating what we're expecting the `keydown` event to look like based the browser.commands configuration. A smaller hardcoded version might look like this:

```javascript
document.addEventListener('keydown', (evt) => {
  if ('y' == evt.key && evt.ctrlKey)
    document.firstElementChild.focus();
});
```

Tested against FF Nightly 59.0a1 (2017-11-19) (64-bit) on ArchLinux.