### PR TITLE
Copy to clipboard in page script, fix #233

### DIFF
--- a/src/modules/clipboard-helper.js
+++ b/src/modules/clipboard-helper.js
@@ -1,0 +1,20 @@
+// Code taken from `context-menu-copy-link-with-types/clipboard-helper.js`
+// as included in repository https://github.com/mdn/webextensions-examples/
+
+// This function must be called in a visible page, such as a browserAction popup
+// or a content script. Calling it in a background page has no effect!
+function copyToClipboard(text, html) {
+    function oncopy(event) {
+        document.removeEventListener("copy", oncopy, true);
+        // Hide the event from the page to prevent tampering.
+        event.stopImmediatePropagation();
+
+        // Overwrite the clipboard content.
+        event.preventDefault();
+        event.clipboardData.setData("text/plain", text);
+    }
+    document.addEventListener("copy", oncopy, true);
+
+    // Requires the clipboardWrite permission, or a user gesture:
+    document.execCommand("copy");
+}

--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -278,14 +278,8 @@ PassFF.Menu = {
     var doc = event.target.ownerDocument;
     var item = PassFF.Menu.getItem(event.target);
     var dataKey = PassFF.Menu.getDataKey(event.target);
-    PassFF.bg_exec('Pass.getPasswordData', item)
-      .then((passwordData) => {
-        let field = doc.getElementById('clipboard-field');
-        field.value = passwordData[dataKey];
-        field.select();
-        doc.execCommand('copy', false, null);
-        window.close();
-      }).catch(logAndDisplayError("Error getting password data on copy to clipboard"));
+    PassFF.bg_exec('Menu.onCopyToClipboard', item, dataKey);
+    window.close();
   },
 
   clearMenuList: function(doc) {


### PR DESCRIPTION
Fixes #233 by adapting the copy to clipboard code from https://github.com/mdn/webextensions-examples/tree/master/context-menu-copy-link-with-types

The previous code did the copying inside the browser action menu which had to remain open until the password data was received from the password store. In cases where the GPG agent would try to open a password prompt, the UI would run into a focus race condition between the password prompt and the browser action menu. In some situations this would even cause Firefox to crash.