### PR TITLE
Fix platform detection for macOS

### DIFF
--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -94,10 +94,12 @@ PassFF.Preferences = (function () {
     'autoFillBlacklist'
   ];
 
-  if (browser.runtime.PlatformOs === "mac") {
-    prefParams.command = '/usr/local/bin/pass';
-    prefParams.commandEnv = 'PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
-  }
+  browser.runtime.getPlatformInfo().then((info) => {
+    if (info.os === "mac") {
+      prefParams.command = '/usr/local/bin/pass';
+      prefParams.commandEnv = 'PATH=/usr/local/bin:/usr/bin:/bin';
+    }
+  });
 
 /* #############################################################################
  * #############################################################################


### PR DESCRIPTION
This fix the issue that `Pass command` and `Environment variables` field didn't set as expected in macOS.

Note: `browser.runtime.PlatformOs` returns an object instead of a string, and `getPlatformInfo()` is the correct method to be used (you might want to check in the console of an add-on).

For more information, check here: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/getPlatformInfo

Btw, I didn't change another `browser.runtime.PlatformOs` instance since the `command` + `y` shortcut works in macOS for some reason, and I prefer not to touch it.