### PR TITLE
WIP: Issue280 rewrite

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -156,17 +156,14 @@ PassFF.Page = (function () {
   }
 
   function setOtherInputs(other) {
+    const goodFieldNames = Object.keys(other);
     getOtherInputs(other).forEach(function (otherInput) {
-      let value;
-      let name = (otherInput.name).toLowerCase();
-      let id = (otherInput.id).toLowerCase();
-      if (other.hasOwnProperty(name)) {
-        value = other[name];
-      } else if (other.hasOwnProperty(id)) {
-        value = other[id];
-      }
-      if (value) {
-        writeValueWithEvents(otherInput, value);
+      let inputFieldNames = readInputNames(otherInput);
+      inputFieldNames = inputFieldNames.filter(Boolean).map((n) => n.toLowerCase());
+      inputFieldNames = inputFieldNames.filter((n) => goodFieldNames.indexOf(n) >= 0);
+      const writtenField = inputFieldNames.pop();
+      if(writtenField) {
+        writeValueWithEvents(otherInput, other[writtenField]);
       }
     });
   }

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -58,6 +58,12 @@ PassFF.Page = (function () {
     ].filter(Boolean).map((n) => n.toLowerCase());
   }
 
+  function findGoodFieldNames(input, goodFieldNames) {
+    const fieldNames = readInputNames(input);
+    goodFieldNames = goodFieldNames.filter(Boolean).map((n) => n.toLowerCase());
+    return fieldNames.filter((n) => goodFieldNames.indexOf(n) >= 0);
+  }
+
   function hasGoodName(input, goodFieldNames) {
     const fieldNames = readInputNames(input);
     goodFieldNames = goodFieldNames.filter(Boolean).map((n) => n.toLowerCase());
@@ -158,9 +164,7 @@ PassFF.Page = (function () {
   function setOtherInputs(other) {
     const goodFieldNames = Object.keys(other);
     getOtherInputs(other).forEach(function (otherInput) {
-      let inputFieldNames = readInputNames(otherInput);
-      inputFieldNames = inputFieldNames.filter((n) => goodFieldNames.indexOf(n) >= 0);
-      const writtenField = inputFieldNames.pop();
+      const writtenField = findGoodFieldNames(otherInput, goodFieldNames).pop();
       if(writtenField) {
         writeValueWithEvents(otherInput, other[writtenField]);
       }

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -58,12 +58,8 @@ PassFF.Page = (function () {
     ].filter(Boolean).map((n) => n.toLowerCase());
   }
 
-  function isGoodName(name, goodNames) {
-    return goodNames.some((n) => { return name.indexOf(n.toLowerCase()) >= 0; });
-  }
-
   function hasGoodName(fieldNames, goodFieldNames) {
-    return fieldNames.some((fn) => { return isGoodName(fn, goodFieldNames); });
+    return goodFieldNames.some((n) => fieldNames.indexOf(n.toLowerCase()) >= 0);
   }
 
   function isPasswordInput(input) {

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -58,27 +58,29 @@ PassFF.Page = (function () {
     ].filter(Boolean).map((n) => n.toLowerCase());
   }
 
-  function hasGoodName(fieldNames, goodFieldNames) {
-    return goodFieldNames.some((n) => fieldNames.indexOf(n.toLowerCase()) >= 0);
+  function hasGoodName(input, goodFieldNames) {
+    const fieldNames = readInputNames(input);
+    goodFieldNames = goodFieldNames.filter(Boolean).map((n) => n.toLowerCase());
+    return goodFieldNames.some((n) => fieldNames.indexOf(n) >= 0);
   }
 
   function isPasswordInput(input) {
     if (input.type === 'password') {
       return true;
     } else if (input.type === 'text') {
-      return hasGoodName(readInputNames(input), PassFF.Preferences.passwordInputNames)
+      return hasGoodName(input, PassFF.Preferences.passwordInputNames)
     }
     return false;
   }
 
   function isLoginInput(input) {
     return (loginInputTypes.indexOf(input.type) >= 0 &&
-            hasGoodName(readInputNames(input), PassFF.Preferences.loginInputNames));
+            hasGoodName(input, PassFF.Preferences.loginInputNames));
   }
 
   function isOtherInputCheck(other) {
     return function (input) {
-      return (hasGoodName(readInputNames(input), Object.keys(other)));
+      return (hasGoodName(input, Object.keys(other)));
     }
   }
 

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -65,9 +65,7 @@ PassFF.Page = (function () {
   }
 
   function hasGoodName(input, goodFieldNames) {
-    const fieldNames = readInputNames(input);
-    goodFieldNames = goodFieldNames.filter(Boolean).map((n) => n.toLowerCase());
-    return goodFieldNames.some((n) => fieldNames.indexOf(n) >= 0);
+    return findGoodFieldNames(input, goodFieldNames).length >= 1;
   }
 
   function isPasswordInput(input) {

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -51,13 +51,15 @@ PassFF.Page = (function () {
   }
 
   function readInputNames(input) {
-    return [input.name,input.getAttribute('autocomplete'),input.id];
+    return [
+      input.name,
+      input.getAttribute('autocomplete'),
+      input.id
+    ].filter(Boolean).map((n) => n.toLowerCase());
   }
 
   function isGoodName(name, goodNames) {
-    if (!name) return false;
-    let nm = name.toLowerCase();
-    return goodNames.some((n) => { return nm.indexOf(n.toLowerCase()) >= 0; });
+    return goodNames.some((n) => { return name.indexOf(n.toLowerCase()) >= 0; });
   }
 
   function hasGoodName(fieldNames, goodFieldNames) {
@@ -159,7 +161,6 @@ PassFF.Page = (function () {
     const goodFieldNames = Object.keys(other);
     getOtherInputs(other).forEach(function (otherInput) {
       let inputFieldNames = readInputNames(otherInput);
-      inputFieldNames = inputFieldNames.filter(Boolean).map((n) => n.toLowerCase());
       inputFieldNames = inputFieldNames.filter((n) => goodFieldNames.indexOf(n) >= 0);
       const writtenField = inputFieldNames.pop();
       if(writtenField) {


### PR DESCRIPTION
Here is the big PR, although the net change is somewhat small.

**This is a WIP** since it changes drastically the behaviour of passff. See 45655eb
**Do not merge**

I will comment commit per commit:

#### 3c0ba5e Refactor function setOtherInputs()

After fixing the fix for issue #280, I noticed the function was wrong: it finds inputs which _ids, names or autocompletes_ match the other fields. Then, it finds which field matches a given input by comparing only _ids and names_.
Thus, I have rewritten setOtherInputs() by using readInputNames().

From the commit message
```
Modified behavior:
* use readInputNames(): check 'autocomplete' attribute besides name & id
* if more than one field matches, use id or 'autocomplete' or name (in this order)
  instead of using name or id.
```

#### 71d7da7 readInputNames() sanitizes its output
It could return _undefined_ object for the autocomplete field. 
This commit also renders useless the check in isGoodName().
I have also split the array declaration on multiple lines for readability and for limiting the line to 80/90 chars.
Does it follow coding standards?  
Feel free to comment and propose another writing. 

Commit message:
```
* filters false values: NaN, undefined, null
* convert to lowercase
```

#### 45655eb Remove isGoodName() & refactor hasGoodName()
Kidding, it renders useless the whole function isGoodName().
*Actually*, this commit is problematic. Since passff adds fewer (P) icon on input fields.

(half an hour later)
Oh, isGoodName(name, goodNames) does not check if _name_ **IS** a _goodName_, it checks if _name_ **CONTAINS** a _goodName_. 
I wasn't aware of this. I'm pretty sure this is correct behaviour for you ;)

Thus, setOtherInputs() was all the more wrong since it checks if a _name_ **is** a _goodName_, wasn't it? :sweat_smile: 

Finally, I guess isGoodName() shouldn't be removed. 
However, could we rename it to containsGoodName? or even a more generic signature contains(container, elt).
hasGoodName() could be renamed to matchesGoodName() or matchesName() or hasMatchingName() (see `man grep` for example)
findGoodFieldNames -> findMatchingFieldNames()
Let me know what you think about these changes.

#### 37ef803 Change hasGoodName() signature. Refactor parents
This change makes sense in 3 ways:
* it prepares the next commits
* all its calls use readInputName() as argument fieldNames. 
* the signature hasGoodName(input, goodNames) makes more (semantic) sense: Does input has good names?

#### bb759bd Add findGoodFieldNames(). Refactor setOtherInputs()
setOtherInputs() does too many things. Let's hand down some lines to a new function.
The new function is basically hasGoodName() with a different output: instead of returning yes/no, it returns an array of matching elements.

#### 5861221 Refactor hasGoodName()
It's free.
Note: This last commit was breaking the field matching. There were no (P) icons anymore and passff couldn't fill any field anymore. But a rebase on the master branch fixed it.

I found a bug during the test process: I expose it there since it can be reproduced with my bug (see 45655eb)
* `Add login input name` in input's contextual menu not working for GitHub's sign up fields https://github.com/join . It fails **silently** to add the name "user[login]". Yes this is silly. We could also add an option to add the id.

Another anecdotal bug https://github.com/passff/passff/issues/294