### PR TITLE
Add foreground color to popup menu

### DIFF
--- a/src/skin/content.css
+++ b/src/skin/content.css
@@ -94,6 +94,7 @@
   display: block;
   float: right;
   white-space: nowrap;
+  color: #000;
 }
 
 .passff_popup_menu button.passff_button {


### PR DESCRIPTION
This adds a foreground-color to the popup menu, to make it readable if the default foreground color in Firefox is set to a light color.
Fixes issue #283.

Putting the color in `.passff_popup_menu *` did not do the trick, but `.passff_popup_menu button.passff_key span` suffices for me.