### PR TITLE
[Discussion] Improve English translation

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -18,7 +18,7 @@
     "message": "Fill and submit"
   },
   "passff_menu_goto_fill": {
-    "message": "Goto, fill"
+    "message": "Goto and fill"
   },
   "passff_menu_goto_fill_and_submit": {
     "message": "Goto, fill and submit"
@@ -30,7 +30,7 @@
     "message": "Display"
   },
   "passff_display_hover": {
-    "message": "Hover mouse pointer to show password"
+    "message": "Hover mouse pointer to show password."
   },
   "passff_toolbar_button_label": {
     "message": "PassFF"
@@ -48,7 +48,7 @@
     "message": "New"
   },
   "passff_button_root_label": {
-    "message": "Display all"
+    "message": "Display top-level"
   },
   "passff_button_context_label": {
     "message": "Display contextual"
@@ -75,10 +75,10 @@
     "message": "Miscellaneous"
   },
   "passff_prefs_mark_fillable": {
-    "message": "Mark fillable forms with an icon-shaped form menu"
+    "message": "Mark fillable input fields with the PassFF icon"
   },
   "passff_prefs_submit_fillable": {
-    "message": "Submit when selected via the form menu"
+    "message": "Submit when selected via the input menu"
   },
   "passff_prefs_handle_http_auth": {
     "message": "Handle HTTP authentication"
@@ -93,13 +93,13 @@
     "message": "Behavior of Enter key"
   },
   "passff_prefs_fields_description": {
-    "message": "Fields are used to find data inside your password repository. PassFF looks login, password and URL up in the password file. If it's a directory, PassFF looks them up in the files of this directory"
+    "message": "Fields are used to find data inside your password repository. PassFF looks login, password and URL up in the password file. If it's a directory, PassFF looks them up in the files of this directory."
   },
   "passff_prefs_password_input_names_label": {
-    "message": "Password form names"
+    "message": "Password input names"
   },
   "passff_prefs_login_input_names_label": {
-    "message": "Login form names"
+    "message": "Login input names"
   },
   "passff_prefs_login_field_names_label": {
     "message": "Login field names"
@@ -111,7 +111,7 @@
     "message": "URL field names"
   },
   "passff_prefs_script_howto": {
-    "message": "See passff.py for changing the environment variables of Pass!"
+    "message": "See passff.py for changing the environment variables of pass."
   },
   "passff_prefs_auto_fill_label": {
     "message": "Try to auto fill page login forms"
@@ -123,7 +123,7 @@
     "message": "Don't auto fill if tab's URL contains one of the strings"
   },
   "passff_prefs_default_length_tooltip": {
-    "message": "The default value for the length of a generated password"
+    "message": "Default length of a generated password"
   },
   "passff_prefs_default_length_label": {
     "message": "Default password length"
@@ -135,7 +135,7 @@
     "message": "Include at least one special character in the password by default"
   },
   "passff_prefs_preferred_new_method_tooltip": {
-    "message": "Whether new passwords default to be automatically generated or to be inserted by user"
+    "message": "Whether PassFF defaults to automatically generated passwords or passwords inserted by user"
   },
   "passff_prefs_preferred_new_method_label": {
     "message": "Preferred new method"
@@ -153,7 +153,7 @@
     "message": "Enable logging to the JavaScript web console"
   },
   "passff_prefs_show_status": {
-    "message": "Show a statusbar in the toolbar menu"
+    "message": "Show a status bar in the toolbar menu"
   },
   "passff_newpassword_window_title": {
     "message": "New Password"
@@ -183,7 +183,7 @@
     "message": "Length"
   },
   "passff_newpassword_inputs_include_symbols_label": {
-    "message": "Include symbols?"
+    "message": "Include specials characters"
   },
   "passff_newpassword_inputs_add_password_button_label": {
     "message": "Insert password"
@@ -192,22 +192,22 @@
     "message": "Generate password"
   },
   "passff_newpassword_inputs_overwrite_password_prompt": {
-    "message": "That password already exists. Are you sure you want to replace it?"
+    "message": "This password already exists. Are you sure you want to replace it?"
   },
   "passff_newpassword_errors_name_is_required": {
-    "message": "A name is required"
+    "message": "A name is required."
   },
   "passff_newpassword_errors_password_is_required": {
-    "message": "A password is required"
+    "message": "A password is required."
   },
   "passff_newpassword_errors_password_confirmation_mismatch": {
-    "message": "The passwords do not match"
+    "message": "The passwords do not match."
   },
   "passff_newpassword_errors_pass_execution_failed": {
-    "message": "Oops, something went wrong"
+    "message": "Oops, something went wrong!"
   },
   "passff_newpassword_errors_unexpected_error": {
-    "message": "Sorry, an unexpected error occurred"
+    "message": "Sorry, an unexpected error occurred!"
   },
   "passff_errors_unexpected_error": {
     "message": "Sorry, an unexpected error occurred. Make sure your preferences are correctly set and that the host app is installed."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -48,7 +48,7 @@
     "message": "New"
   },
   "passff_button_root_label": {
-    "message": "Display root"
+    "message": "Display all"
   },
   "passff_button_context_label": {
     "message": "Display contextual"
@@ -75,31 +75,31 @@
     "message": "Miscellaneous"
   },
   "passff_prefs_mark_fillable": {
-    "message": "Mark fillable input fields with icon"
+    "message": "Mark fillable forms with an icon-shaped form menu"
   },
   "passff_prefs_submit_fillable": {
-    "message": "Submit when selected via icon menu"
+    "message": "Submit when selected via the form menu"
   },
   "passff_prefs_handle_http_auth": {
     "message": "Handle HTTP authentication"
   },
   "passff_prefs_directories_first": {
-    "message": "List directories first in password repository"
+    "message": "List directories first in the toolbar menu"
   },
   "passff_prefs_case_insensitive_search": {
     "message": "Case-insensitive searching"
   },
   "passff_prefs_enter_behavior": {
-    "message": "Behavior of enter key"
+    "message": "Behavior of Enter key"
   },
   "passff_prefs_fields_description": {
-    "message": "Fields are used to find data inside your passwords repository. PassFF will try to find the login, password or url value inside the password data (using the standard syntax) or trying to find a matching child node name"
+    "message": "Fields are used to find data inside your password repository. PassFF looks login, password and URL up in the password file. If it's a directory, PassFF looks them up in the files of this directory"
   },
   "passff_prefs_password_input_names_label": {
-    "message": "Password input names"
+    "message": "Password form names"
   },
   "passff_prefs_login_input_names_label": {
-    "message": "Login input names"
+    "message": "Login form names"
   },
   "passff_prefs_login_field_names_label": {
     "message": "Login field names"
@@ -108,10 +108,10 @@
     "message": "Password field names"
   },
   "passff_prefs_url_field_names_label": {
-    "message": "Url field names"
+    "message": "URL field names"
   },
   "passff_prefs_script_howto": {
-    "message": "See passff.py for changing the command environment!"
+    "message": "See passff.py for changing the environment variables of Pass!"
   },
   "passff_prefs_auto_fill_label": {
     "message": "Try to auto fill page login forms"
@@ -120,7 +120,7 @@
     "message": "Try to auto submit page login forms"
   },
   "passff_prefs_autofill_blacklist_label": {
-    "message": "Don't auto fill if URL contains these"
+    "message": "Don't auto fill if tab's URL contains one of the strings"
   },
   "passff_prefs_default_length_tooltip": {
     "message": "The default value for the length of a generated password"
@@ -132,10 +132,10 @@
     "message": "Whether generated passwords should include symbols by default"
   },
   "passff_prefs_default_include_symbols_label": {
-    "message": "Include symbols by default"
+    "message": "Include at least one special character in the password by default"
   },
   "passff_prefs_preferred_new_method_tooltip": {
-    "message": "Whether new passwords default to being generated or being inserted"
+    "message": "Whether new passwords default to be automatically generated or to be inserted by user"
   },
   "passff_prefs_preferred_new_method_label": {
     "message": "Preferred new method"
@@ -147,13 +147,13 @@
     "message": "Insert"
   },
   "passff_prefs_show_new_password_button": {
-    "message": "Show 'New Password' button in menu"
+    "message": "Show 'New Password' button in the toolbar menu"
   },
   "passff_prefs_enable_logging": {
-    "message": "Enable logging to the Javascript console"
+    "message": "Enable logging to the JavaScript web console"
   },
   "passff_prefs_show_status": {
-    "message": "Show a status line in the toolbar menu"
+    "message": "Show a statusbar in the toolbar menu"
   },
   "passff_newpassword_window_title": {
     "message": "New Password"
@@ -192,16 +192,16 @@
     "message": "Generate password"
   },
   "passff_newpassword_inputs_overwrite_password_prompt": {
-    "message": "That password already exists. Are you sure you want to overwrite it?"
+    "message": "That password already exists. Are you sure you want to replace it?"
   },
   "passff_newpassword_errors_name_is_required": {
-    "message": "Name must be present"
+    "message": "A name is required"
   },
   "passff_newpassword_errors_password_is_required": {
-    "message": "Password must be present"
+    "message": "A password is required"
   },
   "passff_newpassword_errors_password_confirmation_mismatch": {
-    "message": "Password confirmation doesn't match"
+    "message": "The passwords do not match"
   },
   "passff_newpassword_errors_pass_execution_failed": {
     "message": "Oops, something went wrong"
@@ -210,7 +210,7 @@
     "message": "Sorry, an unexpected error occurred"
   },
   "passff_errors_unexpected_error": {
-    "message": "Sorry, an unexpected error occured. Make sure your preferences are correctly set and that the native host app is installed."
+    "message": "Sorry, an unexpected error occurred. Make sure your preferences are correctly set and that the host app is installed."
   },
   "passff_no_entries_found": {
     "message": "No entries matching this URL."


### PR DESCRIPTION
Source: French translation (See PR #319  :+1: )

#### Disclaimer: I'm NOT a native English speaker.

#### Main points

- Use a vocabulary closer to the user experience, and farther from the code, for eg:
  - input | input fields | form > form (*field* is already used for the password data)
  - root > all
  - overwrite > replace
- Improve/Correct
  - url > URL
  - enter key > Enter key
  - URL > tab's URL (more precise)
  - *menu > *toolbar menu* or *form menu*
  - symbols > special characters

#### What could be improved?
- Maybe punctuations. 
- I don't know, tell me!
