### PR TITLE
Do not truncate error message in the statusbar

### DIFF
--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -33,14 +33,10 @@ PassFF.Menu = (function () {
       return;
     }
     let msg = result.stderr;
-    let msg_maxlen = 33;
-    if (msg.length > msg_maxlen) {
-      msg = msg.substr(0, msg_maxlen-3) + "...";
-    }
     let timestamp = result.timestamp.toTimeString();
     timestamp = timestamp.substr(0,8);
     bar.textContent = "[" + timestamp + "] " + result.command
-                    + " -> " + msg + " (" + result.exitCode + ")";
+                    + " -> " + "(" + result.exitCode + ") " + msg;
     window.dispatchEvent(new Event('resize'));
   }
 


### PR DESCRIPTION
- Do not truncate the error message, so that it can be entirely
  selected with Ctrl+A or a triple click.
- Print error code before the error message, so that it is always
  visible.

The error message might not be displayed entirely, does it introduce any bug/problem?

#### Before: master branch
`[15:27:38] show -> gpg: decryption failed: No sec... (2)`

#### With this commit
`[15:25:12] show -> (2) gpg: decryption failed: No secret key `