### PR TITLE
Add an 'Inputs' section in the preferences

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -62,6 +62,9 @@
   "passff_prefs_tab_autofilling": {
     "message": "Automatisches Ausfüllen von Formularen"
   },
+  "passff_prefs_tab_inputs": {
+    "message": "Inputs"
+  },
   "passff_prefs_tab_fields": {
     "message": "Felder in Pass-Datensätzen"
   },
@@ -91,6 +94,9 @@
   },
   "passff_prefs_enter_behavior": {
     "message": "Verhalten der Enter-Taste"
+  },
+  "passff_prefs_inputs_description": {
+    "message": "Inputs are used by PassFF to find fillable input fields in web pages. Optionally, PassFF marks them with a menu to fill them."
   },
   "passff_prefs_fields_description": {
     "message": "Felder werden genutzt, um Daten in deinem Passwort-Repository zu finden. PassFF versucht, den 'login', 'passwort' oder 'url' Wert (entsprechend der Standard-Syntax) oder einen passenden Datensatznamen in den Passwortdaten zu finden."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -62,6 +62,9 @@
   "passff_prefs_tab_autofilling": {
     "message": "Autofilling"
   },
+  "passff_prefs_tab_inputs": {
+    "message": "Inputs"
+  },
   "passff_prefs_tab_fields": {
     "message": "Fields"
   },
@@ -91,6 +94,9 @@
   },
   "passff_prefs_enter_behavior": {
     "message": "Behavior of Enter key"
+  },
+  "passff_prefs_inputs_description": {
+    "message": "Inputs are used by PassFF to find fillable input fields in web pages. Optionally, PassFF marks them with a menu to fill them."
   },
   "passff_prefs_fields_description": {
     "message": "Fields are used to find data inside your password repository. PassFF looks login, password and URL up in the password file. If it's a directory, PassFF looks them up in the files of this directory."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -62,6 +62,9 @@
   "passff_prefs_tab_autofilling": {
     "message": "Remplissage automatique"
   },
+  "passff_prefs_tab_inputs": {
+    "message": "Inputs"
+  },
   "passff_prefs_tab_fields": {
     "message": "Champs"
   },
@@ -91,6 +94,9 @@
   },
   "passff_prefs_enter_behavior": {
     "message": "Comportement de la touche Entrée"
+  },
+  "passff_prefs_inputs_description": {
+    "message": "Inputs are used by PassFF to find fillable input fields in web pages. Optionally, PassFF marks them with a menu to fill them."
   },
   "passff_prefs_fields_description": {
     "message": "Les champs sont utilisés afin de trouver les données dans votre dépôt de mots de passe. PassFF cherche identifiant, mot de passe et URL dans le fichier mot de passe. Si c'est un dossier, PassFF les cherche dans les fichiers de ce dossier."

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -56,6 +56,9 @@
   "passff_prefs_tab_autofilling": {
     "message": "Автозаполнение"
   },
+  "passff_prefs_tab_inputs": {
+    "message": "Inputs"
+  },
   "passff_prefs_tab_fields": {
     "message": "Поля"
   },
@@ -70,6 +73,9 @@
   },
   "passff_prefs_enter_behavior": {
     "message": "Поведение клавиши ввода"
+  },
+  "passff_prefs_inputs_description": {
+    "message": "Inputs are used by PassFF to find fillable input fields in web pages. Optionally, PassFF marks them with a menu to fill them."
   },
   "passff_prefs_fields_description": {
     "message": "Поля которые используются для поиска данных в вашем репозитории паролей. PassFF пытается найти логин, пароль и адреса сайтов в файлах с паролями (используя стандартный синтаксис)."

--- a/src/content/preferences.html
+++ b/src/content/preferences.html
@@ -55,7 +55,16 @@
           </p><p>
             <label>passff_prefs_autofill_blacklist_label</label>
             <input type="text" id="pref_autoFillBlacklist" value="" />
-          </p><p>
+          </p>
+        </fieldset>
+      </div>
+
+      <div class="tab">
+        <input type="radio" name="tab_radio" id="tab1a">
+        <label for="tab1a">passff_prefs_tab_inputs</label>
+        <fieldset>
+          <p class="text">passff_prefs_inputs_description</p>
+          <p>
             <label>passff_prefs_password_input_names_label</label>
             <input type="text" id="pref_passwordInputNames" value="" />
           </p><p>

--- a/src/content/preferences.html
+++ b/src/content/preferences.html
@@ -16,12 +16,6 @@
         <label for="tab0">passff_prefs_tab_general</label>
         <fieldset>
           <p>
-            <input type="checkbox" id="pref_markFillable" />
-            <label for="pref_markFillable">passff_prefs_mark_fillable</label>
-          </p><p>
-            <input type="checkbox" id="pref_submitFillable" />
-            <label for="pref_submitFillable">passff_prefs_submit_fillable</label>
-          </p><p>
             <input type="checkbox" id="pref_caseInsensitiveSearch" />
             <label for="pref_caseInsensitiveSearch">passff_prefs_case_insensitive_search</label>
           </p><p>
@@ -65,6 +59,12 @@
         <fieldset>
           <p class="text">passff_prefs_inputs_description</p>
           <p>
+            <input type="checkbox" id="pref_markFillable" />
+            <label for="pref_markFillable">passff_prefs_mark_fillable</label>
+          </p><p>
+            <input type="checkbox" id="pref_submitFillable" />
+            <label for="pref_submitFillable">passff_prefs_submit_fillable</label>
+          </p><p>
             <label>passff_prefs_password_input_names_label</label>
             <input type="text" id="pref_passwordInputNames" value="" />
           </p><p>


### PR DESCRIPTION
Firstly, the current preferences can be a bit misleading. Indeed, the 'Autofilling' section groups options that do not require Autofilling at all:
- Mark fillable input fields with the PassFF icon
- Submit when selected via the input menu
- Password input names
- Login input names

Secondly, the terminology of PassFF is tricky: "field" stands for 'a field in a password file' and for 'an input field'. Therefore, a description is added to explain the terminology.

The commit also creates all relevant translation entries in French, German and Russian.