### PR TITLE
Prompt for username/url in generate dialog

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -173,6 +173,12 @@
   "passff_newpassword_inputs_password_confirmation_label": {
     "message": "Confirm password"
   },
+  "passff_newpassword_inputs_password_username_label": {
+    "message": "Username"
+  },
+  "passff_newpassword_inputs_password_url_label": {
+    "message": "URL"
+  },
   "passff_newpassword_inputs_additional_info_label": {
     "message": "Additional info"
   },

--- a/src/content/passwordGenerator.html
+++ b/src/content/passwordGenerator.html
@@ -19,6 +19,12 @@
             <label>inputs_password_name_label</label>
             <input type="text" id="gen-password-name" value="" />
           </p><p>
+              <label>inputs_password_username_label</label>
+              <input type="text" id="gen-password-username" value="" />
+          </p><p>
+              <label>inputs_password_url_label</label>
+              <input type="text" id="gen-password-url" value="" />
+          </p><p>
             <label>inputs_password_length_label</label>
             <input type="text" id="gen-password-length" value="16" />
           </p><p>


### PR DESCRIPTION
This adds a prompt for a username/url in the generate dialog. The input fields look like this: https://monad.io/mtdflgki.png

Given those inputs, the entry in the pass manager will end up looking like this:
```
vt&M~BWT#]E.u#2_,
---
test
password: vt&M~BWT#]E.u#2_,
username: test-user
url: test-url
```

If the username/url are omitted then the password manager acts just as it does now.