### PR TITLE
Fix invisible input menu's icon

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -241,6 +241,8 @@ PassFF.Page = (function () {
     if (typeof input.passff_injected !== "undefined") return;
     log.debug("Inject icon", input.id || input.name);
     input.passff_injected = true;
+    input.style["-moz-appearance"] = "none";
+    input.style["-webkit-appearance"] = "none";
     input.style.backgroundRepeat = "no-repeat";
     input.style.backgroundAttachment = "scroll";
     input.style.backgroundSize = "16px 16px";


### PR DESCRIPTION
Input fields with the style '-moz-appearance: window' hide the PassFF icon.

Minimal Working Example

- copy-paste the HTML code below in a HTML file
- open it with Firefox
```
<html>
    <head>
        <meta charset="utf-8" />
    </head>
    <body>
        <input name="login" type="text" style="-moz-appearance:window;">
    </body>
</html>
```

I have also included `-webkit-appearance:none` for the other browsers (anticipating the chrome port...).

Tested on:
* Firefox 52 ESR and Firefox 61.0b13 Dev Edition.
* Linux Debian Stretch