### PR TITLE
Check host app version by semantic versioning

### DIFF
--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -230,12 +230,12 @@ PassFF.Pass = (function () {
             let version = result.version || "0.0";
             const compatible = (function isHostAppCompatible(version) {
               const MIN_VERSION = '1.0.1';
-              return semver().gte(version, MIN_VERSION) || version === "testing";
+              return version === "testing" || semver.gte(version, MIN_VERSION);
             })(version);
             if (!compatible) {
               log.warn("The host app is outdated!", version);
               result.exitCode = -2;
-              result.stderr = "The host app is outdated! v" + version;
+              result.stderr = `The host app (v${version}) is outdated!`;
             } else if (result.exitCode !== 0) {
               log.warn('Script execution failed',
                 result.exitCode, result.stderr, result.stdout);

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -227,9 +227,12 @@ PassFF.Pass = (function () {
         }
         return browser.runtime.sendNativeMessage("passff", args)
           .then((result) => {
-            let version = String(result.version) || "0.0";
-            const COMPATIBLE_VERSION = "1.0.1";
-            if (version < COMPATIBLE_VERSION && version !== "testing") {
+            let version = result.version || "0.0";
+            const compatible = (function isHostAppCompatible(version) {
+              const MIN_VERSION = '1.0.1';
+              return semver().gte(version, MIN_VERSION) || version === "testing";
+            })(version);
+            if (!compatible) {
               log.warn("The host app is outdated!", version);
               result.exitCode = -2;
               result.stderr = "The host app is outdated! v" + version;

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -227,11 +227,12 @@ PassFF.Pass = (function () {
         }
         return browser.runtime.sendNativeMessage("passff", args)
           .then((result) => {
-            let version = result.version || "0.0";
-            if (version !== "1.0.1" && version !== "testing") {
+            let version = String(result.version) || "0.0";
+            const COMPATIBLE_VERSION = "1.0.1";
+            if (version < COMPATIBLE_VERSION && version !== "testing") {
               log.warn("The host app is outdated!", version);
               result.exitCode = -2;
-              result.stderr = "v" + version;
+              result.stderr = "The host app is outdated! v" + version;
             } else if (result.exitCode !== 0) {
               log.warn('Script execution failed',
                 result.exitCode, result.stderr, result.stdout);

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -175,7 +175,7 @@ function fun_name(name) {
  * See https://github.com/passff/passff/pull/342
  */
 
-function semver() {
+const semver = (function semver() {
 
   /**
    * Takes a version string as input and parses it.
@@ -183,12 +183,13 @@ function semver() {
    */
   function parser(version) {
     version = version + "";
-    // This regEx is ^(id)\.(id)(?:\.(id))?(?:ext)$
-    // with id = `0|[1-9]\d*` and ext = `|[\+-].+`
-    const reg = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:|[\+-].+)$/;
-    const m = version.match(reg);
 
-    if (!m) return null;
+    const id = String.raw`(0|[1-9]\d*)`;
+    const ext = String.raw`(?:|[\+-].+)`;
+    const reg = String.raw`^${id}\.${id}(?:\.${id})?${ext}$`;
+    const m = version.trim().match(reg);
+
+    if (!m) throw new TypeError('Invalid Version: ' + version);
 
     return {
       major: +m[1] || 0,
@@ -210,8 +211,6 @@ function semver() {
     v1 = parser(v1);
     v2 = parser(v2);
 
-    if(!v1 || !v2) return NaN;
-
     return (v1.major - v2.major ||
             v1.minor - v2.minor ||
             v1.patch - v2.patch);
@@ -229,8 +228,6 @@ function semver() {
     return comparator(v1,v2) == 0;
   }
 
-  // The API is conservative for now.
-  // It could be expanded later if necessary.
   let publicAPI = { gt, gte, eq };
   return publicAPI;
-}
+})();

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -161,3 +161,76 @@ function fun_name(name) {
     return [PassFF, parts[0]];
   }
 }
+
+/* #############################################################################
+ * #############################################################################
+ *  semantic versioning
+ * #############################################################################
+ */
+
+/*
+ * This implementation has been inspired by npm's semver.
+ *
+ * For in-depth explanations,
+ * See https://github.com/passff/passff/pull/342
+ */
+
+function semver() {
+
+  /**
+   * Takes a version string as input and parses it.
+   * Returns the major, minor and patch identifiers of the version as integers.
+   */
+  function parser(version) {
+    version = version + "";
+    // This regEx is ^(id)\.(id)(?:\.(id))?(?:ext)$
+    // with id = `0|[1-9]\d*` and ext = `|[\+-].+`
+    const reg = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:|[\+-].+)$/;
+    const m = version.match(reg);
+
+    if (!m) return null;
+
+    return {
+      major: +m[1] || 0,
+      minor: +m[2] || 0,
+      patch: +m[3] || 0,
+    };
+  }
+
+  /**
+   * Takes two version strings as input.
+   * Returns an integer. The latter is:
+   *   - negative (<0) if v1 < v2
+   *   - positive (>0) if v1 > v2
+   *   - zero     (=0) if v1 = v2
+   * Notice the symmetry in the relations.
+   * Last but not least, we can sort versions using Array#sort(comparator).
+   */
+  function comparator(v1,v2) {
+    v1 = parser(v1);
+    v2 = parser(v2);
+
+    if(!v1 || !v2) return NaN;
+
+    return (v1.major - v2.major ||
+            v1.minor - v2.minor ||
+            v1.patch - v2.patch);
+  }
+
+  function gt(v1, v2) {
+    return comparator(v1,v2) > 0;
+  }
+
+  function gte(v1, v2) {
+    return comparator(v1,v2) >= 0;
+  }
+
+  function eq(v1, v2) {
+    return comparator(v1,v2) == 0;
+  }
+
+  // The API is conservative for now.
+  // It could be expanded later if necessary.
+  let publicAPI = { gt, gte, eq };
+  return publicAPI;
+}


### PR DESCRIPTION
See https://github.com/passff/passff-host/issues/18

To be able to bugfix the host app without touching PassFF, we have to enforce *semantic versioning* in passff-host.
As a result, PassFF should more loosely check passff-host's version.

Note: The lexicography check requires its operands to be `string`s. Thus, I explicitly coerce `version` to be a `string`.

#### What is left to do?
Let the user know that new versions of passff-host are available.
This will be the object of another PR.