### PR TITLE
Fix dead link to PassFF's installation steps

### DIFF
--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -417,7 +417,7 @@ PassFF.Menu = (function () {
     Array.from(errorBoxMsgs).forEach(function (p) {
       p.textContent = _(p.textContent);
       p.innerHTML = p.innerHTML.replace(/\{([^\}]+)\}/,
-        "<a href=\"https://github.com/passff/passff/blob/master/docs/INSTALLATION.md\">$1</a>");
+        "<a href=\"https://github.com/passff/passff#installation\">$1</a>");
     });
 
     let searchBox = document.getElementById('passff-search-box');


### PR DESCRIPTION
Commit https://github.com/passff/passff/commit/26f935923cc0fc9ffa163e71472c972166698605 broke a link in PassFF.
I randomly found it and fixed it :+1: 

The anchor `#installation`has no effect though.