### PR TITLE
fix z-index issue on e.g. amazon.de login

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -349,8 +349,8 @@ PassFF.Page = (function () {
     popup_menu.style.display  = "block";
 
     // get the largest z-index value and position ourselves above it
-    let z = [...document.querySelectorAll('*')]
-      .filter(e => e.style.position !== "static")
+    let z = [...document.querySelectorAll('body *')]
+      .filter(e => !(e.style.position in ["static", ""]))
       .map(e => window.getComputedStyle(e).zIndex)
       .filter(e => e>0)
       .sort()

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -349,13 +349,11 @@ PassFF.Page = (function () {
     popup_menu.style.display  = "block";
 
     // get the largest z-index value and position ourselves above it
-    let z = [...document.querySelectorAll('body *')]
-      .filter(e => !(e.style.position in ["static", ""]))
-      .map(e => window.getComputedStyle(e).zIndex)
-      .filter(e => e>0)
-      .sort()
-      .slice(-1)[0];
-    popup_menu.style.zIndex = "" + (+z+1 || 1);
+    let z = Math.max(1, ...[...document.querySelectorAll('body *')]
+      .filter(e => ["static",""].indexOf(e) === -1)
+      .map(e => parseInt(window.getComputedStyle(e).zIndex))
+      .filter(e => e>0));
+    popup_menu.style.zIndex = "" + z;
   }
 
   function getPopupEntryItem(target) {

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -348,13 +348,13 @@ PassFF.Page = (function () {
     popup_menu.style.left     = (scrollright + rect.right - 2) + "px";
     popup_menu.style.display  = "block";
 
-    let p = target;
-    let z = 1;
-    while (p = p.parentElement) {
-      let st = window.getComputedStyle(p);
-      if (st.zIndex !== "auto") z += parseInt(st.zIndex);
-    }
-    popup_menu.style.zIndex = "" + z;
+    // get the largest z-index value and position ourselves above it
+    let z = [...document.querySelectorAll('*')]
+      .map(e => window.getComputedStyle(e).zIndex)
+      .filter(e => e>0)
+      .sort()
+      .slice(-1)[0];
+    popup_menu.style.zIndex = "" + (+z+1 || 1);
   }
 
   function getPopupEntryItem(target) {

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -350,6 +350,7 @@ PassFF.Page = (function () {
 
     // get the largest z-index value and position ourselves above it
     let z = [...document.querySelectorAll('*')]
+      .filter(e => e.style.position !== "static")
       .map(e => window.getComputedStyle(e).zIndex)
       .filter(e => e>0)
       .sort()


### PR DESCRIPTION
I've noticed a bug with the (P) popup. Currently, only the z-index of the parent elements are checked, but not of elements nearby (which the popup may overlap). On amazon.de's login page for example they set the 'Anmelden' (login) button to z-index:20, but our popup only has the default z-index of 1. 

This patch uses querySelectorAll to filter through all z-indices and gives the popup the highest found. 

Is there a reason the addon only checked the parents? performance, maybe?
