### PR TITLE
Prompt for additional info on generate

### DIFF
--- a/src/content/passwordGenerator.html
+++ b/src/content/passwordGenerator.html
@@ -25,6 +25,9 @@
             <input type="checkbox" id="gen-include-symbols" checked="true" />
             <label for="gen-include-symbols">inputs_include_symbols_label</label>
           </p><p>
+            <label>inputs_additional_info_label</label>
+            <textarea id="add-additional-info-generate"></textarea>
+          </p><p>
             <button id="gen-save-button">inputs_generate_password_button_label</button>
           </p>
           <div id="gen-errors-container"></div>
@@ -46,7 +49,7 @@
             <input type="password" id="add-password-confirmation" value="" />
           </p><p>
             <label>inputs_additional_info_label</label>
-            <textarea id="add-additional-info"></textarea>
+            <textarea id="add-additional-info-insert"></textarea>
           </p><p>
             <button id="save-button">inputs_add_password_button_label</button>
           </p>

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -560,13 +560,29 @@ PassFF.Pass = (function () {
         .then((result) => { return result.exitCode === 0; });
     },
 
-    generateNewPassword: function (name, length, includeSymbols) {
+    generateNewPassword: function (name, length, includeSymbols, additionalInfo) {
       let args = ['generate', name, length.toString()];
       if (!includeSymbols) {
         args.push('-n');
       }
       return this.executePass(args)
-        .then((result) => { return result.exitCode === 0; });
+        .then((result) => {
+          if (result.exitCode !== 0) {
+            return false;
+          }
+          if (additionalInfo) {
+            return this.executePass([name])
+              .then((result) => {
+                if (result.exitCode !== 0) {
+                  return false;
+                }
+                var pass = result.stdout.split(/\n/);
+                return this.addNewPassword(name, pass, additionalInfo)
+              });
+          } else {
+            return true;
+          }
+        });
     },
 
 // %%%%%%%%%%%%%%%%%%%%%%%%%% Data analysis %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -756,7 +772,7 @@ function handlePasswordGeneration() {
         name                 : document.getElementById('add-password-name').value,
         password             : document.getElementById('add-password').value,
         passwordConfirmation : document.getElementById('add-password-confirmation').value,
-        additionalInfo       : document.getElementById('add-additional-info').value,
+        additionalInfo       : document.getElementById('add-additional-info-insert').value,
       };
     },
     function (inputData) {
@@ -773,11 +789,12 @@ function handlePasswordGeneration() {
         name           : document.getElementById('gen-password-name').value,
         length         : document.getElementById('gen-password-length').value,
         includeSymbols : document.getElementById('gen-include-symbols').checked,
+        additionalInfo : document.getElementById('add-additional-info-generate').value,
       };
     },
     function (inputData) {
       return PassFF.Pass.generateNewPassword(
-        inputData.name, inputData.length, inputData.includeSymbols);
+        inputData.name, inputData.length, inputData.includeSymbols, inputData.additionalInfo);
     }
   );
 


### PR DESCRIPTION
The additional info is added to the new pass entry right after creating
it in a separate step because `pass generate` has no option to append
data to the generated password during creation.

This PR is heavily based on the work by @eklitzke in #335. This PR is a (from my point of view) improved version that I hope will be merged rather than linger around without activity. I am new to JS and Firefox plugin development. So any feedback, both regarding functionality and style, is greatly appreciated.

I felt that allowing any additional data has many advantages over two very specific fields:

* Users can choose and use their own naming scheme
* Users can add more than only two rows
* This greatly reduces the code complexity because we now can reuse the `addNewPassword` directly.