### PR TITLE
Fix OTP pin entry when input type is number

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -729,7 +729,7 @@ PassFF.Page = (function () {
     fillActiveElement: content_function("Page.fillActiveElement",
       function (passwordData) {
         let activeElement = getActiveElement();
-        let inputTypes = Array.concat(loginInputTypes, ["password"]);
+        let inputTypes = Array.concat(loginInputTypes, ["password", "number"]);
         log.debug("Fill active element", activeElement);
         if (activeElement.tagName !== "INPUT"
             || inputTypes.indexOf(activeElement.type) < 0) return;


### PR DESCRIPTION
This will fix filling of OTP pin on Gitea server login page.


Gitea changed its OTP input login page in this commit
https://github.com/go-gitea/gitea/commit/03d6bab64373e883beb6f4867432ad4f12112950