### PR TITLE
Index all password store meta urls on passff init

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -128,6 +128,9 @@
   "passff_prefs_url_field_names_label": {
     "message": "URL field names"
   },
+  "passff_prefs_index_meta_urls_label": {
+    "message": "Index URL fields on startup. This will read all URL field values into browser memory and allow them to be used when passff looks for passwords. (Requires passff-host >=1.2.0)"
+  },
   "passff_prefs_otpauth_field_names_label": {
     "message": "OTP Auth field names"
   },
@@ -262,6 +265,15 @@
   },
   "passff_error_otp_host_version": {
     "message": "OTP support requires the PassFF host app version 1.1.0 or later. Please follow the [official installation instructions]($passffURL$).",
+    "placeholders": {
+      "passffURL": {
+        "content": "$1",
+        "example": "https://gitfoo.org/passff#installation"
+      }
+    }
+  },
+  "passff_error_grep_host_version": {
+    "message": "Indexing meta urls requires the PassFF host app version 1.2.0 or later. Please follow the [official installation instructions]($passffURL$).",
     "placeholders": {
       "passffURL": {
         "content": "$1",

--- a/src/content/preferences.html
+++ b/src/content/preferences.html
@@ -112,6 +112,9 @@
             <label>passff_prefs_url_field_names_label</label>
             <input type="text" id="pref_urlFieldNames" value="" />
           </p><p>
+            <input type="checkbox" id="pref_indexMetaUrls" />
+            <label for="pref_indexMetaUrls">passff_prefs_index_meta_urls_label</label>
+          </p><p>
             <label>passff_prefs_otpauth_field_names_label</label>
             <input type="text" id="pref_otpauthFieldNames" value="" />
           </p>

--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -68,6 +68,7 @@ PassFF.Preferences = (function () {
     loginFieldNames       : 'login,user,username,id',
     passwordFieldNames    : 'passwd,password,pass',
     urlFieldNames         : 'url,http',
+    indexMetaUrls         : false,
     otpauthFieldNames     : 'otpauth',
     autoFill              : false,
     autoSubmit            : false,


### PR DESCRIPTION
There are many situations in which a single pass entry corresponds to multiple completely different web urls. One way of handling this is to list all the urls a password corresponds to inside the password entry using an `url: ` meta tag. However, this is currently not supported by passff (#374). 

In the linked issue, the possibility of using `pass grep` to find these meta urls was discussed. This would generally require decrypting the entire password store on every login, which might be acceptable for some password stores with fast hardware, but probably not a very good experience when using for example a smartcard to decrypt.

What I'm instead proposing in this PR is to only decrypt the entire store once on the initial load of the addon and to create a `Map` of all meta urls contained in the store. This index of meta urls would live in memory and would have a structure like:

```
{
  'services/amazon': ['amazon.com', 'amazon.co.uk', 'audible.com'],
  ...
  'fitness/impuls.ee': ['impuls.ee', 'arcticsport.ee']
}
```  

If this index exists, then the `hostMatchQuality` function can use it as an additional way of checking for matching entries. For example, my amazon entry is located at `services/amazon`, but it's still working on audible.com:

![Screenshot of passff](https://i.imgur.com/FcMrUVY.png)

The trade-off with this approach is that the list of pass entries and corresponding urls is now sitting decrypted in the user's browser memory, however, I believe this is an acceptable trade-off for a lot of users, and as long as this functionality is kept optional and explained next to the setting to turn it on, I think this is the best solution to #374.

This PR is not complete, I would still need to add the corresponding setting to toggle this functionality. I just wanted to submit it early to get some feedback. Does this approach seem reasonable?

This depends on passff/passff-host#38