### PR TITLE
Fix Array.concat usage

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -729,7 +729,7 @@ PassFF.Page = (function () {
     fillActiveElement: content_function("Page.fillActiveElement",
       function (passwordData) {
         let activeElement = getActiveElement();
-        let inputTypes = Array.concat(loginInputTypes, ["password", "number"]);
+        let inputTypes = loginInputTypes.concat(["password", "number"]);
         log.debug("Fill active element", activeElement);
         if (activeElement.tagName !== "INPUT"
             || inputTypes.indexOf(activeElement.type) < 0) return;


### PR DESCRIPTION
This fixes #417 for me on 71.0b3 (64-bit) macos.