### PR TITLE
PassFF.Pass: use urlFieldNames in indexMetaUrls

### DIFF
--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -454,8 +454,12 @@ PassFF.Pass = (function () {
           let fullKey = "";
           let urls = [];
 
+          // build RegExp for detecting metaTag lines
+          let metaTagURLPart = PassFF.Preferences.urlFieldNames.join('|');
+          metaTagURLPart = metaTagURLPart || "host|url";  // fallback
+          let metaTagRegexp = new RegExp("^("+metaTagURLPart+"):",'i');
+
           for (let line of stdout.split("\n")) {
-            let metaTagRegexp = /^(host|url):/;
             if (!metaTagRegexp.test(line)) {
               //reached next fullKey in output
               if (urls.length > 0) {


### PR DESCRIPTION
The pass-ff helper builds the regExp by concatenating by `|`
and adding `^(` in front and `):` at the back. The extension
only checked `/^(url|host):/` (case-sensitive). We now do a
case-insensitive match using the configured fields, falling
back to url|host if it is the empty array.

I'm not sure if the fallback is needed (I did not go trough all the code, maybe indexing should just stop if there are no `urlFieldNames`, maybe this is always set)

(Works on my machine)