### PR TITLE
Parse _VERSIONHOLDER_ as 0.0.0-development

### DIFF
--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -214,6 +214,15 @@ const semver = (function semver() {
   function parser(version) {
     version = version + "";
 
+    // _VERSIONHOLDER_ alias 0.0.0-development
+    if (version === "_VERSIONHOLDER_") {
+      return {
+        major: 0,
+        minor: 0,
+        patch: 0,
+      }
+    }
+
     const id = String.raw`(0|[1-9]\d*)`;
     const ext = String.raw`(?:|[\+-].+)`;
     const reg = String.raw`^${id}\.${id}(?:\.${id})?${ext}$`;


### PR DESCRIPTION
Fix
```
[PassFF.menu] Runtime port has crashed: refresh_all Error: "Invalid Version: _VERSIONHOLDER_" util.js:66:14
    logPrototype moz-extension://XXX/modules/util.js:66
    background_exec moz-extension://XXX/modules/util.js:137
```
This way, I can simply clone passff-host, and use `/home/user/code/src/github.com/passff/passff-host/src/passff.py` as path in my `passff.json`.