### PR TITLE
Lift `rateLoginInput` heuristics from `ratePasswordInput`

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -128,11 +128,12 @@ PassFF.Page = (function () {
   }
 
   function rateLoginInput(input) {
-    if (loginInputTypes.indexOf(input.type) < 0) {
-      return 0;
-    } else {
+    if (input.type === 'email') {
+      return 100;
+    } else if (input.type === 'text') {
       return rateInputNames(input, PassFF.Preferences.loginInputNames);
     }
+    return 0;
   }
 
   function rateOtpInput(input) {


### PR DESCRIPTION
My use case is: for some reason, the email field is not detected on
Discord. This means I have to either 1) type in my email or 2) inspect
element and change the empty `name=""` to something from my login input
list. This change directly copies the implementation of
`ratePasswordInput`. I tested on Discord, GitHub, and Google login pages
and everything still appears to work.

---

I didn't inspect my changes thoroughly and only copy-pasted from directly above in `ratePasswordInput`. I don't know if returning 100 is what we want, but it seems to do the trick. Let me know if there's anything I failed to consider.

---

Fix #433 