### PR TITLE
Allow to configure alternate Enter key behavior

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -104,6 +104,12 @@
   "passff_prefs_enter_behavior": {
     "message": "Verhalten der Enter-Taste"
   },
+  "passff_prefs_shift_enter_behavior": {
+    "message": "Verhalten der Shift-Enter-Taste"
+  },
+  "passff_prefs_ctrl_enter_behavior": {
+    "message": "Verhalten der Ctrl-Enter-Taste"
+  },
   "passff_prefs_inputs_description": {
     "message": "Diese Bezeichner werden von PassFF benutzt, um befüllbare Eingabefelder auf Webseiten zu finden. Optional platziert PassFF in jedem gefundenen Eingabefeld eine Menü-Schaltfläche."
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -23,6 +23,12 @@
   "passff_menu_goto_fill_and_submit": {
     "message": "Goto, fill and submit"
   },
+  "passff_menu_goto_fill_new_tab": {
+    "message": "Goto and fill (in a new tab)"
+  },
+  "passff_menu_goto_fill_and_submit_new_tab": {
+    "message": "Goto, fill and submit (in a new tab)"
+  },
   "passff_menu_goto": {
     "message": "Goto"
   },
@@ -103,6 +109,12 @@
   },
   "passff_prefs_enter_behavior": {
     "message": "Behavior of Enter key"
+  },
+  "passff_prefs_shift_enter_behavior": {
+    "message": "Behavior of Shift-Enter key"
+  },
+  "passff_prefs_ctrl_enter_behavior": {
+    "message": "Behavior of Ctrl-Enter key"
   },
   "passff_prefs_inputs_description": {
     "message": "Inputs are used by PassFF to find fillable input fields in web pages. Optionally, PassFF marks them with a menu to fill them."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -23,6 +23,12 @@
   "passff_menu_goto_fill_and_submit": {
     "message": "Aller, remplir et valider"
   },
+  "passff_menu_goto_fill_new_tab": {
+    "message": "Aller et remplir (dans un nouvel onglet)"
+  },
+  "passff_menu_goto_fill_and_submit_new_tab": {
+    "message": "Aller, remplir et valider (dans un nouvel onglet)"
+  },
   "passff_menu_goto": {
     "message": "Aller"
   },
@@ -103,6 +109,12 @@
   },
   "passff_prefs_enter_behavior": {
     "message": "Comportement de la touche Entrée"
+  },
+  "passff_prefs_shift_enter_behavior": {
+    "message": "Comportement de la touche Maj-Entrée"
+  },
+  "passff_prefs_ctrl_enter_behavior": {
+    "message": "Comportement de la touche Ctrl-Entrée"
   },
   "passff_prefs_inputs_description": {
     "message": "Les entrées sont utilisées par PassFF afin de trouver les champs d'entrée remplissables dans les pages web. Facultativement, PassFF les marque d'un menu qui permet de les remplir."

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -104,6 +104,12 @@
   "passff_prefs_enter_behavior": {
     "message": "Zachowanie klawisza Enter"
   },
+  "passff_prefs_shift_enter_behavior": {
+    "message": "Zachowanie klawisza Shift-Enter"
+  },
+  "passff_prefs_ctrl_enter_behavior": {
+    "message": "Zachowanie klawisza Ctrl-Enter"
+  },
   "passff_prefs_inputs_description": {
     "message": "Pola są używane przez PassFF do wyszukiwania pól tekstowych do wypełnienia. Opcjonalnie, PassFF oznacza je menu do wypełniania."
   },

--- a/src/content/preferences.html
+++ b/src/content/preferences.html
@@ -42,6 +42,37 @@
               <option value="1">passff_menu_goto_fill</option>
               <option value="2">passff_menu_fill_and_submit</option>
               <option value="3">passff_menu_fill</option>
+              <option value="4">passff_menu_goto_fill_and_submit_new_tab</option>
+              <option value="5">passff_menu_goto_fill_new_tab</option>
+              <option value="6">passff_menu_copy_password</option>
+              <option value="7">passff_menu_copy_login</option>
+              <option value="8">passff_menu_display</option>
+            </select>
+          </p><p>
+            <label>passff_prefs_shift_enter_behavior</label>
+            <select id="pref_shiftEnterBehavior">
+              <option value="0">passff_menu_goto_fill_and_submit</option>
+              <option value="1">passff_menu_goto_fill</option>
+              <option value="2">passff_menu_fill_and_submit</option>
+              <option value="3">passff_menu_fill</option>
+              <option value="4">passff_menu_goto_fill_and_submit_new_tab</option>
+              <option value="5">passff_menu_goto_fill_new_tab</option>
+              <option value="6">passff_menu_copy_password</option>
+              <option value="7">passff_menu_copy_login</option>
+              <option value="8">passff_menu_display</option>
+            </select>
+          </p><p>
+            <label>passff_prefs_ctrl_enter_behavior</label>
+            <select id="pref_ctrlEnterBehavior">
+              <option value="0">passff_menu_goto_fill_and_submit</option>
+              <option value="1">passff_menu_goto_fill</option>
+              <option value="2">passff_menu_fill_and_submit</option>
+              <option value="3">passff_menu_fill</option>
+              <option value="4">passff_menu_goto_fill_and_submit_new_tab</option>
+              <option value="5">passff_menu_goto_fill_new_tab</option>
+              <option value="6">passff_menu_copy_password</option>
+              <option value="7">passff_menu_copy_login</option>
+              <option value="8">passff_menu_display</option>
             </select>
           </p><p>
             <label>passff_prefs_recognised_suffixes</label>

--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -183,8 +183,8 @@ PassFF.Menu = (function () {
       }
       menuState['items'] = PassFF.Pass.rootItems;
       createMenuList();
-    } else if (!event.shiftKey && event.keyCode != 40 && event.keyCode != 38) {
-      /* NOT: SHIFT, DOWN ARROW, UP ARROW */
+    } else if (!event.shiftKey && event.key != 'Control' && event.keyCode != 40 && event.keyCode != 38) {
+      /* NOT: SHIFT, CTRL, DOWN ARROW, UP ARROW */
       document.getElementById('passff-search-box').focus();
     }
   }
@@ -297,7 +297,7 @@ PassFF.Menu = (function () {
           if (PassFF.mode === "itemPicker") {
             PassFF.Menu.onPickItem(getItem(this));
           } else {
-            PassFF.Menu.onEnter(getItem(this), event.shiftKey);
+            PassFF.Menu.onEnter(getItem(this), event.shiftKey, event.ctrlKey);
             window.close();
           }
         };
@@ -502,17 +502,21 @@ PassFF.Menu = (function () {
 
 // %%%%%%%%%%%%% Event handlers that are delegated to background %%%%%%%%%%%%%%%
 
-    onEnter: background_function("Menu.onEnter", function (itemId, shiftKey) {
+    onEnter: background_function("Menu.onEnter", function (itemId, shiftKey, ctrlKey) {
       let item = PassFF.Pass.getItemById(itemId);
-      log.debug("Enter press on item", item.fullKey, shiftKey);
-      switch (PassFF.Preferences.enterBehavior) {
+      log.debug("Enter press on item", item.fullKey, shiftKey, ctrlKey);
+      let behavior =
+        ctrlKey   ? PassFF.Preferences.ctrlEnterBehavior :
+        shiftKey  ? PassFF.Preferences.shiftEnterBehavior :
+                    PassFF.Preferences.enterBehavior
+      switch (behavior) {
         case 0:
           //goto url, fill, submit
-          PassFF.Page.goToItemUrl(item, shiftKey, true, true);
+          PassFF.Page.goToItemUrl(item, false, true, true);
           break;
         case 1:
           //goto url, fill
-          PassFF.Page.goToItemUrl(item, shiftKey, true, false);
+          PassFF.Page.goToItemUrl(item, false, true, false);
           break;
         case 2:
           //fill, submit
@@ -521,6 +525,34 @@ PassFF.Menu = (function () {
         case 3:
           //fill
           PassFF.Page.fillInputs(null, item, false);
+          break;
+        case 4:
+          //goto url, fill, submit (new tab)
+          PassFF.Page.goToItemUrl(item, true, true, true);
+          break;
+        case 5:
+          //goto url, fill (new tab)
+          PassFF.Page.goToItemUrl(item, true, true, false);
+          break;
+        case 6:
+          //copy password
+          PassFF.Pass.getPasswordData(item)
+            .then((passwordData) => {
+              if (typeof passwordData === "undefined") return;
+              PassFF.Page.copyToClipboard(passwordData.password);
+            });
+          break;
+        case 7:
+          //copy login
+          PassFF.Pass.getPasswordData(item)
+            .then((passwordData) => {
+              if (typeof passwordData === "undefined") return;
+              PassFF.Page.copyToClipboard(passwordData.login);
+            });
+          break;
+        case 8:
+          //display
+          PassFF.Pass.displayItem(item);
           break;
       }
     }),

--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -77,6 +77,8 @@ PassFF.Preferences = (function () {
     caseInsensitiveSearch : true,
     handleHttpAuth        : true,
     enterBehavior         : 0,
+    shiftEnterBehavior    : 4,
+    ctrlEnterBehavior     : 3,
     defaultPasswordLength : 16,
     defaultIncludeSymbols : true,
     preferInsert          : 0,

--- a/src/skin/menu.css
+++ b/src/skin/menu.css
@@ -114,7 +114,7 @@ div.buttonbox button.reload {
 
 .results select {
   width: 100%;
-  height: 11rem;
+  height: 13rem;
   box-sizing: border-box;
   -moz-appearance: none;
   border-color: #b6b6b3;


### PR DESCRIPTION
Implements #441

Implements various new behaviors on Enter key, and allow to configure Shift-Enter and Ctrl-Enter too. Shift-Enter was set to open in a new tab when the behavior was *go to* and it is still the default behavior but it is now configurable.