### PR TITLE
Skip inputs with placeholder containing `search`

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -68,7 +68,7 @@ PassFF.Page = (function () {
 
   function readInputNames(input) {
     let inputNames = [input.name || "", input.id || ""];
-    if (input.hasAttribute('placeholder')) {
+    if (input.hasAttribute('placeholder') && input.getAttribute('placeholder').toLowerCase().indexOf('search') === -1) {
       inputNames.push(input.getAttribute('placeholder'));
     }
 


### PR DESCRIPTION
such as Gmail's search bar.

Another issue that I noticed (which is solved by this PR in gmail's case, but might be present elsewhere), is that with the current version of passff, the pass icon on the gmail search bar is repeated (`background` attribute is set to `repeat`):
![image](https://user-images.githubusercontent.com/6243438/107034635-476e0200-67b7-11eb-9db5-bde98df2ec0f.png)
