### PR TITLE
HTTP Auth: limit the number of popups

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -17,7 +17,6 @@ PassFF.Auth = (function () {
   // Find a currentAuth for the current realm at the root URI as per [0]
   // [0] https://datatracker.ietf.org/doc/html/rfc7235#section-2.2
   function getAuthByRootUriAndRealm(rootUri, realm) {
-    log.debug(rootUri, realm, "currentAuths", currentAuths);
     let auth = currentAuths.filter(a => (
         a.rootUri === rootUri
         && a.realm === realm
@@ -55,14 +54,11 @@ PassFF.Auth = (function () {
     log.debug("onAuthRequired", details.requestId, details.url);
     let auth = getAuthById(details.requestId);
     if (auth === null) {
-      log.debug('no auth for', details.requestId);
       let rootUri = getRootUri(details.url);
        auth = getAuthByRootUriAndRealm(
          rootUri,
          details.realm
        );
-       log.debug("existing for ", rootUri,
-         details.realm, auth);
        // If we still have an unresolved promise for the same Root/Realm
        // (i.e., if the promise has already resolved and we're back here,
        // the previous resolved data is not good, and we should retry)

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -7,10 +7,28 @@ PassFF.Auth = (function () {
     */
 
   var currentAuths = [];
+  var promises = {};
 
   function getAuthById(requestId) {
     let auth = currentAuths.filter(a => a.requestId === requestId);
     return (!auth.length) ? null : auth[0];
+  }
+
+  // Find a currentAuth for the current realm at the root URI as per [0]
+  // [0] https://datatracker.ietf.org/doc/html/rfc7235#section-2.2
+  function getAuthByRootUriAndRealm(rootUri, realm) {
+    log.debug(rootUri, realm, "currentAuths", currentAuths);
+    let auth = currentAuths.filter(a => (
+        a.rootUri === rootUri
+        && a.realm === realm
+    ));
+    return (!auth.length) ? null : auth[0];
+  }
+
+  // Get the root URI (scheme + authority [0]) from a URL
+  // [0] https://datatracker.ietf.org/doc/html/rfc3986#section-3.2
+  function getRootUri(url) {
+      return url.replace(/^(.*\/\/[^\/?#]*).*$/,"$1");
   }
 
   function cancelAuth(auth) {
@@ -37,22 +55,48 @@ PassFF.Auth = (function () {
     log.debug("onAuthRequired", details.requestId, details.url);
     let auth = getAuthById(details.requestId);
     if (auth === null) {
-      auth = {
-        requestId: null,
-        requestUrl: null,
-        popupId: null,
-        popupClose: null,
-        resolveItem: null,
-        resolveAttempts: 0,
-        contextItems: [],
-      };
-      currentAuths.push(auth);
+      log.debug('no auth for', details.requestId);
+      let rootUri = getRootUri(details.url);
+       auth = getAuthByRootUriAndRealm(
+         rootUri,
+         details.realm
+       );
+       log.debug("existing for ", rootUri,
+         details.realm, auth);
+       // If we still have an unresolved promise for the same Root/Realm
+       // (i.e., if the promise has already resolved and we're back here,
+       // the previous resolved data is not good, and we should retry)
+       if (auth !== null && auth.resolveItem == null) {
+         log.debug("Auth window already showing for realm "
+           + details.realm
+           + " from root "
+           + rootUri
+           + ", skipping popup");
+           return promises[auth.requestId];
+       } else {
+        auth = {
+          requestId: null,
+          requestUrl: null,
+          rootUri: null,
+          realm: null,
+          popupId: null,
+          popupClose: null,
+          promise: null,
+          resolveItem: null,
+          resolveAttempts: 0,
+          contextItems: [],
+        };
+
+        currentAuths.push(auth);
+      }
     }
 
     auth.requestId = details.requestId;
     auth.requestUrl = details.url;
+    auth.rootUri= getRootUri(details.url);
+    auth.realm = details.realm;
     auth.contextItems = PassFF.Pass.getUrlMatchingItems(auth.requestUrl);
-    return new Promise((resolve, reject) => {
+    promises[auth.requestId] = new Promise((resolve, reject) => {
       auth.resolve = resolve;
       PassFF.Page.goToAutoFillPending()
         .then(function (pending) {
@@ -96,6 +140,7 @@ PassFF.Auth = (function () {
           browser.windows.onRemoved.addListener(auth.popupClose);
         });
     });
+    return promises[auth.requestId];
   }
 
 /* #############################################################################


### PR DESCRIPTION
This change prevents from opening a large number of popups for embedded
objects requiring HTTP Auth (e.g., public or cached page data).

We do so by searching the currentAuths array for existing entries that
share the same Root URI and the same realm. If one is found, we don't
open a new popup, but return the Promise associated with the first auth
instead.

fixes: #343, #322

Signed-off-by: Olivier Mehani <shtrom@ssji.net>