### PR TITLE
adding otp name defaults for microsoft and gitlab

### DIFF
--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -64,7 +64,7 @@ PassFF.Preferences = (function () {
   var prefParams = {
     passwordInputNames    : 'passwd,password,pass',
     loginInputNames       : 'login,user,mail,email,tel,username,opt_login,log,usr_name',
-    otpInputNames         : 'otp,code',
+    otpInputNames         : 'otp,code,otc,user[otp_attempt]',
     buttonInputQueries    : 'button:not([type=reset])\ninput[type=submit]\ninput[type=button]\n[role=button]',
     loginFieldNames       : 'login,user,username,id',
     passwordFieldNames    : 'passwd,password,pass',


### PR DESCRIPTION
login.microsoftonline.com: `otc`
gitlab.com: `user[otp_attempt]`