### PR TITLE
Bugfix: you can now leave regex for hiding items empty.

### DIFF
--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -438,6 +438,7 @@ PassFF.Pass = (function () {
             }
           });
 
+          var isInUseHiddenRegex = PassFF.Preferences.filterPathRegex.length != 0;
           var isHiddenRegex = new RegExp(PassFF.Preferences.filterPathRegex.join("|"), 'i');
 
           allItems.slice().reverse().forEach(item => {
@@ -455,7 +456,7 @@ PassFF.Pass = (function () {
                                            || isUrlField(item.key)
                                            || isOtpauthField(item.key));
             item.hasFields = item.children.some(c => allItems[c].isField);
-            item.isHidden = isHiddenRegex.test(item.fullKey);
+            item.isHidden = isInUseHiddenRegex && isHiddenRegex.test(item.fullKey);
           });
 
           this.indexMetaUrls();


### PR DESCRIPTION
There is a bug where the top level view is enforced instead of the contextual view. This will occur when the field “Regex for hiding items” is empty (or only empty lines). Empty regex's will always pass Regex.test(). So, all items will be hidden, which is obviously not intended behavior.

I think I fixed it, but embarrassingly enough, I have trouble building and installing the extension (and so my patch) to test it. If someone could give some instructions, I would like to test it any ways.