### PR TITLE
Support Cloudflare otp field name

### DIFF
--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -64,7 +64,7 @@ PassFF.Preferences = (function () {
   var prefParams = {
     passwordInputNames    : 'passwd,password,pass',
     loginInputNames       : 'login,user,mail,email,tel,username,opt_login,log,usr_name',
-    otpInputNames         : 'otp,code,otc,user[otp_attempt]',
+    otpInputNames         : 'otp,code,otc,user[otp_attempt],twofactor_token',
     buttonInputQueries    : 'button:not([type=reset])\ninput[type=submit]\ninput[type=button]\n[role=button]',
     loginFieldNames       : 'login,user,username,id',
     passwordFieldNames    : 'passwd,password,pass',


### PR DESCRIPTION
The field name for Cloudflare [two-factor authentication](https://dash.cloudflare.com/two-factor) is twofactor_token. Adding it to the list of otp fields.