### PR TITLE
Fix infinite loop on text field input

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -529,7 +529,7 @@ PassFF.Page = (function () {
     bestFitItem = PassFF.Pass.findBestFitItem(matchItems, url);
 
     var obs = new MutationObserver(onNodeAdded);
-    obs.observe(document, { attributes: false, childList: true, subtree: true });
+    obs.observe(document, { attributes: true, childList: false, subtree: true, attributeFilter: ["id", "name"] });
     onNodeAdded();
 
     return PassFF.Page.goToAutoFillPending()

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -78,6 +78,7 @@ PassFF.Page = (function () {
   }
 
   function readInputNames(input) {
+    log.debug("test")
     let inputNames = [input.name || "", input.id || ""];
     let placeholder = input.getAttribute('placeholder');
     if (placeholder && placeholder.toLowerCase().indexOf('search') === -1) {
@@ -529,7 +530,7 @@ PassFF.Page = (function () {
     bestFitItem = PassFF.Pass.findBestFitItem(matchItems, url);
 
     var obs = new MutationObserver(onNodeAdded);
-    obs.observe(document, { attributes: true, childList: true, subtree: true });
+    obs.observe(document, { attributes: false, childList: true, subtree: true });
     onNodeAdded();
 
     return PassFF.Page.goToAutoFillPending()
@@ -790,7 +791,7 @@ PassFF.Page = (function () {
         if (inputElements.filter(inp => inp[1] == "password").length === 0) {
           if (inputElements.length == 0 || cautious) {
             log.debug("fillInputs: No relevant login input elements recognized.");
-            return null;
+            return Promise.resolve();
           } else {
             log.debug("fillInputs: Warning: no password inputs found!");
           }

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -78,7 +78,6 @@ PassFF.Page = (function () {
   }
 
   function readInputNames(input) {
-    log.debug("test")
     let inputNames = [input.name || "", input.id || ""];
     let placeholder = input.getAttribute('placeholder');
     if (placeholder && placeholder.toLowerCase().indexOf('search') === -1) {


### PR DESCRIPTION
Repro steps (Firefox 104.0):
* Open a page with an input text field, like some issue from https://github.com/passff/passff/issues and focus (click inside) the comment input text field
* Open the debugger (CTRL+SHIFT+I) and see recurring `Empty string passed to getElementById()` error.

On some text fields, this leads to noticeable slowdown (Zendesk). Found out this is due to MutationObserver notifying on attributes in infinite loop in some pages. Setting this to false fixed this issue. Tested on ~100 different sites (~20 with otp).

Also noticed, that the debug console is complaining about a null being returned instead of an empty Promise, so fixed that as well.