### PR TITLE
Autofill lonely OTP inputs

### DIFF
--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -787,7 +787,10 @@ PassFF.Page = (function () {
     fillInputs: content_function("Page.fillInputs",
       function (item, andSubmit, cautious) {
         refocus();
-        if (inputElements.filter(inp => inp[1] == "password").length === 0) {
+        if (
+          inputElements.filter(inp => inp[1] == "password" || inp[1] == "otp")
+            .length === 0
+        ) {
           if (inputElements.length == 0 || cautious) {
             log.debug("fillInputs: No relevant login input elements recognized.");
             return Promise.resolve();


### PR DESCRIPTION
OTPs are often challenged on a new page after the username and password was entered. This change allows this workflow.

This should not impose additional security risks given that OTPs are:
* only valid for a short amount of time
* only valuable in combination with an identity (e.g. login, session, ...)